### PR TITLE
[#10 #14] FIX openidm (object) is not defined (rhino export global context)

### DIFF
--- a/custom-scripted-connector-bundler/pom.xml
+++ b/custom-scripted-connector-bundler/pom.xml
@@ -93,6 +93,12 @@
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mozilla</groupId>
+                    <artifactId>rhino</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <asm.version>5.0.4</asm.version>
         <!-- quartz 2.x is not compatible yet -->
         <quartz.version>1.8.6_1</quartz.version>
-        <rhino.version>1.7R4_1</rhino.version>
+        <rhino.version>1.7.14_2</rhino.version>
         <groovy.version>2.4.7</groovy.version>
 
         <!-- OSGi/Felix versions -->


### PR DESCRIPTION
https://github.com/OpenIdentityPlatform/commons/pull/110