### PR TITLE
CVE-2019-17554 CVE-2019-17555 CVE-2020-1925 Bump Apache Olingo

### DIFF
--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -595,7 +595,7 @@
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-core</artifactId>
-            <version>4.0.0-beta-01</version>
+            <version>4.10.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
- Improper Restriction of XML External Entity Reference in Apache Olingo
- Improper input validation in Apache Olingo
- Server-Side Request Forgery (SSRF) in Apache Olingo