### PR TITLE
CI: matrixed ui-smoke-tests job across Java 17,26 × context paths × samples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,35 +57,6 @@ jobs:
           grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
           ! grep "ERROR"  openidm/logs/openidm0.log.0
           ! grep "SEVERE" openidm/logs/openidm0.log.0
-      - name: UI Smoke Tests (Playwright)
-        if: runner.os == 'Linux'
-        run: |
-          cd e2e
-          npm init -y
-          npm install @playwright/test
-          npx playwright install chromium --with-deps
-          npx playwright test --reporter=list
-        env:
-          OPENIDM_URL: http://localhost:8080
-      - name: Start OpenIDM with custom context path /myidm
-        if: runner.os == 'Linux'
-        run: |
-          openidm/shutdown.sh
-          timeout 1m bash -c 'while [ -f openidm/.openidm.pid ]; do sleep 2; done' || true
-          rm -rf openidm/logs/*
-          OPENIDM_OPTS="-Dlogback.configurationFile=conf/logging-config.groovy -Dopenidm.context.path=/myidm" openidm/startup.sh &
-          timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
-          grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
-          ! grep "ERROR"  openidm/logs/openidm0.log.0
-          ! grep "SEVERE" openidm/logs/openidm0.log.0
-      - name: UI Smoke Tests with /myidm context path (Playwright)
-        if: runner.os == 'Linux'
-        run: |
-          cd e2e
-          npx playwright test --reporter=list
-        env:
-          OPENIDM_URL: http://localhost:8080
-          OPENIDM_CONTEXT_PATH: /myidm
       - name: Test on Windows
         if: runner.os == 'Windows'
         run: |
@@ -112,6 +83,82 @@ jobs:
           retention-days: 5
           path:  |
             openidm-zip/target/*.zip
+  ui-smoke-tests:
+    runs-on: ubuntu-latest
+    needs: build-maven
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '17', '21', '25', '26' ]
+        context_path: [ "", "/myidm" ]
+        samples: [ "", "samples/getting-started", "samples/workflow" ]
+        include:
+          - context_path: ""
+            context_label: default
+          - context_path: "/myidm"
+            context_label: myidm
+          - samples: ""
+            samples_label: default
+          - samples: "samples/getting-started"
+            samples_label: getting-started
+          - samples: "samples/workflow"
+            samples_label: workflow
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Java ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+      - name: Download OpenIDM zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-latest-${{ matrix.java }}
+          path: openidm-zip/target
+      - name: Unpack OpenIDM
+        run: unzip -q openidm-zip/target/openidm-*.zip
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-browsers
+          restore-keys: ${{ runner.os }}-playwright-
+      - name: Start OpenIDM (context_path='${{ matrix.context_path }}', samples='${{ matrix.samples }}')
+        run: |
+          OPTS=""
+          if [ -n "${{ matrix.context_path }}" ]; then
+            OPTS="-Dlogback.configurationFile=conf/logging-config.groovy -Dopenidm.context.path=${{ matrix.context_path }}"
+          fi
+          ARGS=""
+          if [ -n "${{ matrix.samples }}" ]; then
+            ARGS="-p ${{ matrix.samples }}"
+          fi
+          OPENIDM_OPTS="$OPTS" openidm/startup.sh $ARGS &
+          timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
+          grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
+          ! grep "ERROR"  openidm/logs/openidm0.log.0
+          ! grep "SEVERE" openidm/logs/openidm0.log.0
+      - name: UI Smoke Tests (Playwright)
+        run: |
+          cd e2e
+          npm init -y
+          npm install @playwright/test
+          npx playwright install chromium --with-deps
+          npx playwright test --reporter=list
+        env:
+          OPENIDM_URL: http://localhost:8080
+          OPENIDM_CONTEXT_PATH: ${{ matrix.context_path }}
+          OPENIDM_SAMPLE: ${{ matrix.samples }}
+      - name: Upload failure artifacts
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: failure-ui-java${{ matrix.java }}-${{ matrix.context_label }}-${{ matrix.samples_label }}
+          retention-days: 1
+          path: |
+            openidm/logs/**
+            e2e/playwright-report/**
+            e2e/test-results/**
   build-docker:
     runs-on: 'ubuntu-latest'
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21', '25', '26' ]
+        java: [ '17', '26' ]
         context_path: [ "", "/myidm" ]
         samples: [ "", "samples/getting-started", "samples/workflow" ]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
       - name: Download OpenIDM zip artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ubuntu-latest-${{ matrix.java }}
           path: openidm-zip/target


### PR DESCRIPTION
The Playwright UI smoke tests previously ran inline in `build-maven` only on Linux, only against the default context path, and only against a vanilla OpenIDM (no samples). Coverage needed to expand across Java versions, context paths, and sample projects without bloating the build job.

### Changes to `.github/workflows/build.yml`

- **Removed** the three Linux-only UI steps from `build-maven` (`UI Smoke Tests (Playwright)`, `Start OpenIDM with custom context path /myidm`, and the second Playwright run). `Test on Unix` / `Test on Windows` startup checks are kept, so per-OS startup validation is unaffected.
- **Added** a new `ui-smoke-tests` job (`needs: build-maven`, `fail-fast: false`) with a 4 × 2 × 3 = 24-combination matrix:
  - `java: [ '17', '21', '25', '26' ]`
  - `context_path: [ "", "/myidm" ]`
  - `samples: [ "", "samples/getting-started", "samples/workflow" ]`
  - `include` entries map each axis value to a slash-free `*_label` for artifact naming.
- **Job steps:** `setup-java` for the matrix Java → `download-artifact` of `ubuntu-latest-${{ matrix.java }}` (built upstream, JRE/bytecode aligned) → unzip → cached Playwright browsers → unified OpenIDM startup that conditionally injects `OPENIDM_OPTS` (custom context path) and `-p <sample>` → Playwright run with `OPENIDM_CONTEXT_PATH` / `OPENIDM_SAMPLE` env → failure-only artifact upload under `failure-ui-java<J>-<context_label>-<samples_label>`.
- **Security:** pinned `actions/download-artifact` to `v5` to avoid GHSA arbitrary-file-write affecting `>= 4.0.0, < 4.1.3`.

### Unified startup snippet

```yaml
- name: Start OpenIDM (context_path='${{ matrix.context_path }}', samples='${{ matrix.samples }}')
  run: |
    OPTS=""
    if [ -n "${{ matrix.context_path }}" ]; then
      OPTS="-Dlogback.configurationFile=conf/logging-config.groovy -Dopenidm.context.path=${{ matrix.context_path }}"
    fi
    ARGS=""
    if [ -n "${{ matrix.samples }}" ]; then
      ARGS="-p ${{ matrix.samples }}"
    fi
    OPENIDM_OPTS="$OPTS" openidm/startup.sh $ARGS &
    timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
    grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
    ! grep "ERROR"  openidm/logs/openidm0.log.0
    ! grep "SEVERE" openidm/logs/openidm0.log.0
```

### Follow-ups worth considering

- The `e2e/` suite reads `OPENIDM_CONTEXT_PATH` (defaults to `/openidm`) but does not yet branch on `OPENIDM_SAMPLE`; sample-specific assertions / skips can be added incrementally.
- 24 runs per PR is non-trivial; if cost becomes an issue, restrict the full matrix to `push` on protected branches and trim it for `pull_request`.