### PR TITLE
ci: dump openidm logs after UI smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,18 @@ jobs:
             openidm/logs/**
             e2e/playwright-report/**
             e2e/test-results/**
+      - name: Print openidm logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -d openidm/logs ]; then
+            find openidm/logs -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- | while read -r f; do
+              echo "===== $f ====="
+              cat "$f"
+            done
+          else
+            echo "openidm/logs directory not found"
+          fi
   build-docker:
     runs-on: 'ubuntu-latest'
     services:


### PR DESCRIPTION
The `ui-smoke-tests` workflow uploads `openidm/logs` only on failure, making post-run diagnosis from the Actions UI cumbersome.

### Changes
- Added a final `Print openidm logs` step to the `ui-smoke-tests` job in `.github/workflows/build.yml`.
  - Runs with `if: always()` so logs surface on both pass and fail.
  - Enumerates files under `openidm/logs` sorted by mtime (oldest → newest) and prints each with a `===== <path> =====` header.
  - No-ops with a clear message if `openidm/logs` is absent.

```yaml
- name: Print openidm logs
  if: ${{ always() }}
  shell: bash
  run: |
    if [ -d openidm/logs ]; then
      find openidm/logs -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- | while read -r f; do
        echo "===== $f ====="
        cat "$f"
      done
    else
      echo "openidm/logs directory not found"
    fi
```

Note: relies on GNU `find -printf`; the job pins `runs-on: ubuntu-latest`, so this is safe here.