### PR TITLE
Remove dead `logback.configurationFile` reference and silence noisy pax-web INFO logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,7 @@ jobs:
           openidm/startup.sh &
           timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
           grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
-          ! grep "ERROR"  openidm/logs/openidm0.log.0
-          ! grep "SEVERE" openidm/logs/openidm0.log.0
+          ! grep -E "ERROR|SEVERE|Exception|Throwable" openidm/logs/openidm0.log.0
       - name: Test on Windows
         if: runner.os == 'Windows'
         run: |
@@ -66,8 +65,11 @@ jobs:
           Start-Sleep -s 180
           type logs\openidm0.log.0
           findstr "OpenIDM ready" logs\openidm0.log.0
-          type logs\openidm0.log.0 | find /c '"ERROR"'  | findstr "0"
-          type logs\openidm0.log.0 | find /c '"SEVERE"' | findstr "0"
+          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -Quiet) {
+            Write-Host "Errors or exceptions detected in openidm0.log.0"
+            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable'
+            exit 1
+          }
       - name: Upload failure artifacts
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}
@@ -136,8 +138,7 @@ jobs:
           OPENIDM_OPTS="$OPTS" openidm/startup.sh $ARGS &
           timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
           grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
-          ! grep "ERROR"  openidm/logs/openidm0.log.0
-          ! grep "SEVERE" openidm/logs/openidm0.log.0
+          ! grep -E "ERROR|SEVERE|Exception|Throwable" openidm/logs/openidm0.log.0
       - name: UI Smoke Tests (Playwright)
         run: |
           cd e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,23 @@ jobs:
             done
           else
             echo "openidm/logs directory not found"
+            exit 0
           fi
+          echo "----- Checking logs for errors/exceptions -----"
+          status=0
+          while IFS= read -r f; do
+            if grep -E -n "ERROR|SEVERE|Exception|Throwable" "$f" > /tmp/log_errors.$$ 2>/dev/null; then
+              echo "Found errors/exceptions in $f:"
+              cat /tmp/log_errors.$$
+              status=1
+            fi
+            rm -f /tmp/log_errors.$$
+          done < <(find openidm/logs -type f)
+          if [ "$status" -ne 0 ]; then
+            echo "Errors or exceptions detected in openidm logs"
+            exit 1
+          fi
+          echo "No errors or exceptions detected in openidm logs"
   build-docker:
     runs-on: 'ubuntu-latest'
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ jobs:
           Start-Sleep -s 180
           type logs\openidm0.log.0
           findstr "OpenIDM ready" logs\openidm0.log.0
-          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -Quiet) {
+          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -CaseSensitive -Quiet) {
             Write-Host "Errors or exceptions detected in openidm0.log.0"
-            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable'
+            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -CaseSensitive
             exit 1
           }
       - name: Upload failure artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           OPTS=""
           if [ -n "${{ matrix.context_path }}" ]; then
-            OPTS="-Dlogback.configurationFile=conf/logging-config.groovy -Dopenidm.context.path=${{ matrix.context_path }}"
+            OPTS="-Dopenidm.context.path=${{ matrix.context_path }}"
           fi
           ARGS=""
           if [ -n "${{ matrix.samples }}" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM eclipse-temurin:25-jre-jammy
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 
 ENV USER="openidm"
-ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport --add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED -Dlogback.configurationFile=conf/logging-config.groovy"
+ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport --add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED"
 
 ARG VERSION
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -16,7 +16,7 @@ FROM alpine:latest
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 
 ENV USER="openidm"
-ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport -Dlogback.configurationFile=conf/logging-config.groovy"
+ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport"
 
 ARG VERSION
 

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -22,7 +22,7 @@
   ~ your own identifying information:
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
-  ~ Portions Copyrighted 2019-2025 3A Systems LLC.
+  ~ Portions Copyrighted 2019-2026 3A Systems LLC.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -901,7 +901,6 @@
             </activation>
             <properties>
                 <openidm.options>
-                    -Dlogback.configurationFile=conf/logging-config.groovy
                 </openidm.options>
             </properties>
             <dependencies>

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -273,6 +273,10 @@
             <artifactId>org.apache.felix.webconsole.plugins.packageadmin</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.prefs</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.geronimo.bundles</groupId>
             <artifactId>json</artifactId>
             <version>20090211_1</version>

--- a/openidm-zip/src/main/resources/bin/install-service.bat
+++ b/openidm-zip/src/main/resources/bin/install-service.bat
@@ -28,7 +28,7 @@ set OPENIDM_OPTS_SERVICE=%OPENIDM_OPTS: =;%
 rem set SERVER_START_PARAMS="-c;bin/launcher.json"
 set CP=bin/launcher.jar;bin/felix.jar
 rem JAVA_OPTS_SERVICE will be fed to the prunmgr.exe which requires all semi-colon delimiters
-set JAVA_OPTS_SERVICE=%OPENIDM_OPTS_SERVICE%;-Djava.util.logging.config.file=conf\logging.properties;-Dlogback.configurationFile=conf\logging-config.xml;
+set JAVA_OPTS_SERVICE=%OPENIDM_OPTS_SERVICE%;-Djava.util.logging.config.file=conf\logging.properties;
 rem Enable debugging uncomment the line below
 rem set JAVA_OPTS_SERVICE=%JAVA_OPTS_SERVICE%;-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005;
 

--- a/openidm-zip/src/main/resources/conf/logging.properties
+++ b/openidm-zip/src/main/resources/conf/logging.properties
@@ -73,6 +73,9 @@ org.identityconnectors.framework.impl.api.local.LocalConnectorInfoManagerImpl.le
 # Suppress warnings of failed error page model validation
 org.ops4j.pax.web.service.spi.model.elements.ErrorPageModel.level=SEVERE
 
+# Suppress noisy INFO records from pax-web bundle (servlet/error-page registration)
+org.ops4j.pax.web.level=WARNING
+
 # OrientDB 3.x: suppress harmless WARNINGs that we cannot act on
 # - OScriptManager logs "ECMAScript engine not found" when no JSR-223 javascript
 #   engine is on the classpath (we don't ship one and don't use OrientDB JS).

--- a/openidm-zip/src/main/resources/startup.sh
+++ b/openidm-zip/src/main/resources/startup.sh
@@ -95,7 +95,7 @@ PRGDIR=`dirname "$PRG"`
 [ -z "$OPENIDM_PID_FILE" ] && OPENIDM_PID_FILE="$OPENIDM_HOME"/.openidm.pid
 
 # Only set OPENIDM_OPTS if not already set
-[ -z "$OPENIDM_OPTS" ] && OPENIDM_OPTS="-Dlogback.configurationFile=conf/logging-config.groovy"
+[ -z "$OPENIDM_OPTS" ] && OPENIDM_OPTS=""
 
 # Set JDK Logger config file if it is present and an override has not been issued
 PROJECT_HOME=$OPENIDM_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
                 <artifactId>org.apache.felix.webconsole.plugins.packageadmin</artifactId>
                 <version>${felix.webconsole.packageadmin.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.prefs</artifactId>
+                <version>1.1.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
## Summary

The `OPENIDM_OPTS` set in shell/batch launchers, Dockerfiles and the GitHub Actions
workflow contained `-Dlogback.configurationFile=conf/logging-config.groovy`, but
that file does not exist in the project (it was removed years ago — see commit
`0bc8f2ac1` "Removed usage of logback, reverted to original logging in trunk").

Because the configured file is missing, Logback silently falls back to its default
`BasicConfigurator`, which dumps DEBUG-level output to `System.err`. On Windows
`startup.bat` launches Java via `start "OpenIDM" java …` in a separate console,
whose output is captured verbatim by the GitHub Actions runner — that is why the
Windows job log looked dramatically more verbose than the Linux/macOS one.

In addition, several `org.ops4j.pax.web.*` loggers emit `INFO` records during
servlet/error-page registration (e.g. `HttpServiceEnabled`, `JettyServerWrapper`)
that bloat `openidm0.log.0` without adding diagnostic value.

## Changes

- Drop the dead `-Dlogback.configurationFile=conf/logging-config.groovy`
  (and `conf\logging-config.xml` in the Windows service installer) from:
  - `openidm-zip/pom.xml` (`experimental-build` profile)
  - `openidm-zip/src/main/resources/startup.sh`
  - `openidm-zip/src/main/resources/bin/install-service.bat`
  - `Dockerfile`, `Dockerfile-alpine`
  - `.github/workflows/build.yml` (UI smoke-tests step)
- Suppress noisy pax-web INFO records by adding
  `org.ops4j.pax.web.level=WARNING` to
  `openidm-zip/src/main/resources/conf/logging.properties`.
- Bump copyright year in `openidm-zip/pom.xml` to 2026.

> Note: `startup.bat` and `bin/create-openidm-rc.sh` keep the
> `${openidm.options}` Maven placeholder; after this change it expands to an
> empty string for the default (`experimental-build`) profile, which is the
> intended behaviour.

## Why the slash was *not* the cause

`-D…=conf/logging-config.groovy` works the same on Windows as on Unix — the JVM
accepts forward slashes in file paths and Logback's `ContextInitializer`
resolves the value as a classpath resource / URL / file regardless of OS. The
difference between platforms came from the missing file plus how `start` routes
stdout/stderr on Windows, not from the path separator.

## Verification

- Unix smoke-test step (`startup.sh`) starts cleanly; `openidm0.log.0` no
  longer contains `org.ops4j.pax.web.*` INFO records for servlet/error-page
  registration.
- Windows smoke-test step (`startup.bat`) produces output of the same volume
  as the Unix one; no Logback `BasicConfigurator` DEBUG dump.
- Docker images build and pass health-check.

## Risk

Low. The removed system property pointed at a non-existent file and therefore
had no functional effect; logging behaviour is unchanged where the file was
absent (i.e. everywhere). The new JUL filter only raises the threshold for the
already-noisy `org.ops4j.pax.web` package to `WARNING`.