### PR TITLE
fix(samples/workflow): honor `openidm.context.path` in Accept Notice script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,7 @@ jobs:
           openidm/startup.sh &
           timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
           grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
-          ! grep "ERROR"  openidm/logs/openidm0.log.0
-          ! grep "SEVERE" openidm/logs/openidm0.log.0
+          ! grep -E "ERROR|SEVERE|Exception|Throwable" openidm/logs/openidm0.log.0
       - name: Test on Windows
         if: runner.os == 'Windows'
         run: |
@@ -66,8 +65,11 @@ jobs:
           Start-Sleep -s 180
           type logs\openidm0.log.0
           findstr "OpenIDM ready" logs\openidm0.log.0
-          type logs\openidm0.log.0 | find /c '"ERROR"'  | findstr "0"
-          type logs\openidm0.log.0 | find /c '"SEVERE"' | findstr "0"
+          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -Quiet) {
+            Write-Host "Errors or exceptions detected in openidm0.log.0"
+            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable'
+            exit 1
+          }
       - name: Upload failure artifacts
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}
@@ -136,8 +138,7 @@ jobs:
           OPENIDM_OPTS="$OPTS" openidm/startup.sh $ARGS &
           timeout 3m bash -c 'until grep -q "OpenIDM ready" openidm/logs/openidm0.log.0 ; do sleep 5; done' || cat openidm/logs/openidm0.log.0
           grep -q "OpenIDM ready" openidm/logs/openidm0.log.0
-          ! grep "ERROR"  openidm/logs/openidm0.log.0
-          ! grep "SEVERE" openidm/logs/openidm0.log.0
+          ! grep -E "ERROR|SEVERE|Exception|Throwable" openidm/logs/openidm0.log.0
       - name: UI Smoke Tests (Playwright)
         run: |
           cd e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,23 @@ jobs:
             done
           else
             echo "openidm/logs directory not found"
+            exit 0
           fi
+          echo "----- Checking logs for errors/exceptions -----"
+          status=0
+          while IFS= read -r f; do
+            if grep -E -n "ERROR|SEVERE|Exception|Throwable" "$f" > /tmp/log_errors.$$ 2>/dev/null; then
+              echo "Found errors/exceptions in $f:"
+              cat /tmp/log_errors.$$
+              status=1
+            fi
+            rm -f /tmp/log_errors.$$
+          done < <(find openidm/logs -type f)
+          if [ "$status" -ne 0 ]; then
+            echo "Errors or exceptions detected in openidm logs"
+            exit 1
+          fi
+          echo "No errors or exceptions detected in openidm logs"
   build-docker:
     runs-on: 'ubuntu-latest'
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ jobs:
           Start-Sleep -s 180
           type logs\openidm0.log.0
           findstr "OpenIDM ready" logs\openidm0.log.0
-          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -Quiet) {
+          if (Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -CaseSensitive -Quiet) {
             Write-Host "Errors or exceptions detected in openidm0.log.0"
-            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable'
+            Select-String -Path logs\openidm0.log.0 -Pattern 'ERROR|SEVERE|Exception|Throwable' -CaseSensitive
             exit 1
           }
       - name: Upload failure artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           OPTS=""
           if [ -n "${{ matrix.context_path }}" ]; then
-            OPTS="-Dlogback.configurationFile=conf/logging-config.groovy -Dopenidm.context.path=${{ matrix.context_path }}"
+            OPTS="-Dopenidm.context.path=${{ matrix.context_path }}"
           fi
           ARGS=""
           if [ -n "${{ matrix.samples }}" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM eclipse-temurin:25-jre-jammy
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 
 ENV USER="openidm"
-ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport --add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED -Dlogback.configurationFile=conf/logging-config.groovy"
+ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport --add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED"
 
 ARG VERSION
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -16,7 +16,7 @@ FROM alpine:latest
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 
 ENV USER="openidm"
-ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport -Dlogback.configurationFile=conf/logging-config.groovy"
+ENV OPENIDM_OPTS="-server -XX:+UseContainerSupport"
 
 ARG VERSION
 

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -22,7 +22,7 @@
   ~ your own identifying information:
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
-  ~ Portions Copyrighted 2019-2025 3A Systems LLC.
+  ~ Portions Copyrighted 2019-2026 3A Systems LLC.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -901,7 +901,6 @@
             </activation>
             <properties>
                 <openidm.options>
-                    -Dlogback.configurationFile=conf/logging-config.groovy
                 </openidm.options>
             </properties>
             <dependencies>

--- a/openidm-zip/pom.xml
+++ b/openidm-zip/pom.xml
@@ -273,6 +273,10 @@
             <artifactId>org.apache.felix.webconsole.plugins.packageadmin</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.prefs</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.geronimo.bundles</groupId>
             <artifactId>json</artifactId>
             <version>20090211_1</version>

--- a/openidm-zip/src/main/resources/bin/install-service.bat
+++ b/openidm-zip/src/main/resources/bin/install-service.bat
@@ -28,7 +28,7 @@ set OPENIDM_OPTS_SERVICE=%OPENIDM_OPTS: =;%
 rem set SERVER_START_PARAMS="-c;bin/launcher.json"
 set CP=bin/launcher.jar;bin/felix.jar
 rem JAVA_OPTS_SERVICE will be fed to the prunmgr.exe which requires all semi-colon delimiters
-set JAVA_OPTS_SERVICE=%OPENIDM_OPTS_SERVICE%;-Djava.util.logging.config.file=conf\logging.properties;-Dlogback.configurationFile=conf\logging-config.xml;
+set JAVA_OPTS_SERVICE=%OPENIDM_OPTS_SERVICE%;-Djava.util.logging.config.file=conf\logging.properties;
 rem Enable debugging uncomment the line below
 rem set JAVA_OPTS_SERVICE=%JAVA_OPTS_SERVICE%;-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005;
 

--- a/openidm-zip/src/main/resources/conf/logging.properties
+++ b/openidm-zip/src/main/resources/conf/logging.properties
@@ -73,6 +73,9 @@ org.identityconnectors.framework.impl.api.local.LocalConnectorInfoManagerImpl.le
 # Suppress warnings of failed error page model validation
 org.ops4j.pax.web.service.spi.model.elements.ErrorPageModel.level=SEVERE
 
+# Suppress noisy INFO records from pax-web bundle (servlet/error-page registration)
+org.ops4j.pax.web.level=WARNING
+
 # OrientDB 3.x: suppress harmless WARNINGs that we cannot act on
 # - OScriptManager logs "ECMAScript engine not found" when no JSR-223 javascript
 #   engine is on the classpath (we don't ship one and don't use OrientDB JS).

--- a/openidm-zip/src/main/resources/samples/workflow/workflow/contractorOnboarding.bpmn20.xml
+++ b/openidm-zip/src/main/resources/samples/workflow/workflow/contractorOnboarding.bpmn20.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright (c) 2011-2015 ForgeRock AS. All rights reserved.
+  Portions Copyright 2026 3A Systems, LLC.
 -->
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definitions" xsi:schemaLocation="              http://www.omg.org/spec/BPMN/20100524/MODEL http://local.openicf.forgerock.org/BPMN20.xsd">
   <process id="contractorOnboarding" name="Contractor onboarding process" isExecutable="true">
@@ -98,8 +99,12 @@
 
                 // Automatically send the user a password reset email
                 // Current limitation with supplying locale via http headers requires the call to be made via http
+                def openidmContextPath = identityServer.getProperty('openidm.context.path', '/openidm')
+                if (!openidmContextPath.startsWith('/')) {
+                    openidmContextPath = '/' + openidmContextPath
+                }
                 openidm.action("external/rest", "call", [
-                    "url": "https://localhost:"+identityServer.getProperty('openidm.port.https')+"/openidm/selfservice/reset?_action=submitRequirements",
+                    "url": "https://localhost:"+identityServer.getProperty('openidm.port.https')+openidmContextPath+"/selfservice/reset?_action=submitRequirements",
                     "method": "POST",
                     "headers": [
                         "Content-Type": "application/json",

--- a/openidm-zip/src/main/resources/startup.sh
+++ b/openidm-zip/src/main/resources/startup.sh
@@ -95,7 +95,7 @@ PRGDIR=`dirname "$PRG"`
 [ -z "$OPENIDM_PID_FILE" ] && OPENIDM_PID_FILE="$OPENIDM_HOME"/.openidm.pid
 
 # Only set OPENIDM_OPTS if not already set
-[ -z "$OPENIDM_OPTS" ] && OPENIDM_OPTS="-Dlogback.configurationFile=conf/logging-config.groovy"
+[ -z "$OPENIDM_OPTS" ] && OPENIDM_OPTS=""
 
 # Set JDK Logger config file if it is present and an override has not been issued
 PROJECT_HOME=$OPENIDM_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
                 <artifactId>org.apache.felix.webconsole.plugins.packageadmin</artifactId>
                 <version>${felix.webconsole.packageadmin.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.prefs</artifactId>
+                <version>1.1.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
### Problem

The `samples/workflow` end-to-end smoke job
`ui-smoke-tests (… , /myidm, samples/workflow)` consistently fails on
both Java 17 and Java 26 in
[Build run #25805813364](https://github.com/OpenIdentityPlatform/OpenIDM/actions/runs/25805813364)
while every other matrix combination is green:

| context_path | sample              | result   |
|--------------|---------------------|----------|
| (default)    | samples/workflow    | ✅ pass |
| /myidm       | samples/getting-started | ✅ pass |
| /myidm       | (no sample)         | ✅ pass |
| **/myidm**   | **samples/workflow**| ❌ fail |

The job's final step (`Print openidm logs`) scans
`openidm/logs/*` for `ERROR|SEVERE|Exception|Throwable` and exits 1 if
anything matches. With `-Dopenidm.context.path=/myidm` the workflow
sample's `Accept Notice` Groovy script task in
`contractorOnboarding.bpmn20.xml` was calling a hard-coded REST URL:

```groovy
"url": "https://localhost:" + identityServer.getProperty('openidm.port.https')
       + "/openidm/selfservice/reset?_action=submitRequirements"