### PR TITLE
[#186] Fix "Internal Error" in mapping Sample Source / Single Record Reconciliation when first property has no `source`

### DIFF
--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/DataAssociationManagementView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/DataAssociationManagementView.js
@@ -72,16 +72,13 @@ define([
             this.data.numRepresentativeProps = this.getNumRepresentativeProps();
             // Only keep properties that actually define a "source"/"target"; a leading
             // undefined value would break the sample search query. See discussion #186.
-            this.data.sourceProps = _.chain(this.mapping.properties)
-                .pluck("source")
+            // Use native Array filter/slice (lodash 3 _.first ignores the count arg).
+            this.data.sourceProps = _.pluck(this.mapping.properties, "source")
                 .filter(function(source){ return !!source; })
-                .first(this.data.numRepresentativeProps)
-                .value();
-            this.data.targetProps = _.chain(this.mapping.properties)
-                .pluck("target")
+                .slice(0, this.data.numRepresentativeProps);
+            this.data.targetProps = _.pluck(this.mapping.properties, "target")
                 .filter(function(target){ return !!target; })
-                .first(this.data.numRepresentativeProps)
-                .value();
+                .slice(0, this.data.numRepresentativeProps);
             this.data.hideSingleRecordReconButton = mappingUtils.readOnlySituationalPolicy(this.mapping.policies);
 
             this.data.reconAvailable = false;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/DataAssociationManagementView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/association/DataAssociationManagementView.js
@@ -70,8 +70,18 @@ define([
             this.mapping = this.getCurrentMapping();
             this.mappingSync = this.getSyncNow();
             this.data.numRepresentativeProps = this.getNumRepresentativeProps();
-            this.data.sourceProps = _.pluck(this.mapping.properties,"source").slice(0,this.data.numRepresentativeProps);
-            this.data.targetProps = _.pluck(this.mapping.properties,"target").slice(0,this.data.numRepresentativeProps);
+            // Only keep properties that actually define a "source"/"target"; a leading
+            // undefined value would break the sample search query. See discussion #186.
+            this.data.sourceProps = _.chain(this.mapping.properties)
+                .pluck("source")
+                .filter(function(source){ return !!source; })
+                .first(this.data.numRepresentativeProps)
+                .value();
+            this.data.targetProps = _.chain(this.mapping.properties)
+                .pluck("target")
+                .filter(function(target){ return !!target; })
+                .first(this.data.numRepresentativeProps)
+                .value();
             this.data.hideSingleRecordReconButton = mappingUtils.readOnlySituationalPolicy(this.mapping.policies);
 
             this.data.reconAvailable = false;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/behaviors/SingleRecordReconciliationView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/behaviors/SingleRecordReconciliationView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems, LLC.
  */
 
 define([
@@ -79,7 +80,14 @@ define([
         },
 
         setupSearch: function(){
-            var autocompleteProps = _.pluck(this.data.mapping.properties,"source").slice(0,this.getNumRepresentativeProps());
+            // Only keep properties that actually define a "source"; otherwise the
+            // first representative property may be undefined and break the sample
+            // search query (empty _sortKeys= => HTTP 500). See discussion #186.
+            var autocompleteProps = _.chain(this.data.mapping.properties)
+                .pluck("source")
+                .filter(function(source){ return !!source; })
+                .first(this.getNumRepresentativeProps())
+                .value();
 
             mappingUtils.setupSampleSearch($("#findSampleSource",this.$el), this.data.mapping, autocompleteProps, _.bind(function(item) {
                 conf.globalData.testSyncSource = item;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/behaviors/SingleRecordReconciliationView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/behaviors/SingleRecordReconciliationView.js
@@ -83,11 +83,10 @@ define([
             // Only keep properties that actually define a "source"; otherwise the
             // first representative property may be undefined and break the sample
             // search query (empty _sortKeys= => HTTP 500). See discussion #186.
-            var autocompleteProps = _.chain(this.data.mapping.properties)
-                .pluck("source")
+            // Use native Array filter/slice (lodash 3 _.first ignores the count arg).
+            var autocompleteProps = _.pluck(this.data.mapping.properties, "source")
                 .filter(function(source){ return !!source; })
-                .first(this.getNumRepresentativeProps())
-                .value();
+                .slice(0, this.getNumRepresentativeProps());
 
             mappingUtils.setupSampleSearch($("#findSampleSource",this.$el), this.data.mapping, autocompleteProps, _.bind(function(item) {
                 conf.globalData.testSyncSource = item;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/AttributesGridView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/AttributesGridView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems, LLC.
  */
 
 define([
@@ -111,7 +112,14 @@ define([
                 this.data.mapProps = mapProps;
 
                 if (this.data.usesDynamicSampleSource) {
-                    let autocompleteProps = _.pluck(this.model.mapping.properties,"source").slice(0, this.model.numRepresentativeProps);
+                    // Only keep properties that actually define a "source"; otherwise the
+                    // first representative property may be undefined and break the sample
+                    // search query (empty _sortKeys= => HTTP 500). See discussion #186.
+                    let autocompleteProps = _.chain(this.model.mapping.properties)
+                        .pluck("source")
+                        .filter((source) => !!source)
+                        .first(this.model.numRepresentativeProps)
+                        .value();
 
                     mappingUtils.setupSampleSearch($("#findSampleSource", this.$el), this.model.mapping, autocompleteProps, (item)  => {
                         item.IDMSampleMappingName = this.model.mapping.name;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/AttributesGridView.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/properties/AttributesGridView.js
@@ -115,11 +115,10 @@ define([
                     // Only keep properties that actually define a "source"; otherwise the
                     // first representative property may be undefined and break the sample
                     // search query (empty _sortKeys= => HTTP 500). See discussion #186.
-                    let autocompleteProps = _.chain(this.model.mapping.properties)
-                        .pluck("source")
+                    // Use native Array filter/slice (lodash 3 _.first ignores the count arg).
+                    let autocompleteProps = _.pluck(this.model.mapping.properties, "source")
                         .filter((source) => !!source)
-                        .first(this.model.numRepresentativeProps)
-                        .value();
+                        .slice(0, this.model.numRepresentativeProps);
 
                     mappingUtils.setupSampleSearch($("#findSampleSource", this.$el), this.model.mapping, autocompleteProps, (item)  => {
                         item.IDMSampleMappingName = this.model.mapping.name;

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/util/MappingUtils.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/util/MappingUtils.js
@@ -108,9 +108,11 @@ define([
                 }
 
                 searchDelegate.searchResults(mapping.source, cleanProps, query).then(function(response) {
-                    if(response) {
+                    if(response && response.length) {
                         searchList = response;
-                        callback([response]);
+                        // searchResults already returns an array of records; pass it
+                        // through as-is (selectize expects a flat array of options).
+                        callback(response);
                     } else {
                         searchList = [];
 

--- a/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/util/MappingUtils.js
+++ b/openidm-ui/openidm-ui-admin/src/main/js/org/forgerock/openidm/ui/admin/mapping/util/MappingUtils.js
@@ -65,11 +65,14 @@ define([
 
     obj.setupSampleSearch = function(el, mapping, autocompleteProps, selectSuccessCallback){
         var searchList,
-            selectedItem;
+            selectedItem,
+            // Guard against empty/undefined entries (e.g. properties without a "source").
+            cleanProps = _.compact(autocompleteProps),
+            primaryProp = cleanProps[0];
 
         el.selectize({
-            valueField: autocompleteProps[0],
-            searchField: autocompleteProps,
+            valueField: primaryProp,
+            searchField: cleanProps,
             maxOptions: 10,
             create: false,
             onChange: function() {
@@ -96,15 +99,15 @@ define([
                 item: function(item, escape) {
                     selectedItem = item;
 
-                    return "<div>" +escape(item[autocompleteProps[0]]) +"</div>";
+                    return "<div>" +escape(item[primaryProp]) +"</div>";
                 }
             },
             load: function(query, callback) {
-                if (!query.length || query.length < 2 || !autocompleteProps.length) {
+                if (!query.length || query.length < 2 || !cleanProps.length) {
                     return callback();
                 }
 
-                searchDelegate.searchResults(mapping.source, autocompleteProps, query).then(function(response) {
+                searchDelegate.searchResults(mapping.source, cleanProps, query).then(function(response) {
                     if(response) {
                         searchList = response;
                         callback([response]);

--- a/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/mapping/util/MappingUtilsTest.js
+++ b/openidm-ui/openidm-ui-admin/src/test/qunit/org/forgerock/openidm/ui/admin/mapping/util/MappingUtilsTest.js
@@ -1,5 +1,63 @@
 define([
-    "org/forgerock/openidm/ui/admin/mapping/util/MappingUtils"
-], function (MappingUtils) {
+    "jquery",
+    "sinon",
+    "org/forgerock/openidm/ui/admin/mapping/util/MappingUtils",
+    "org/forgerock/openidm/ui/common/delegates/SearchDelegate"
+], function ($, sinon, MappingUtils, SearchDelegate) {
     QUnit.module('MappingUtils Tests');
+
+    QUnit.test("setupSampleSearch passes a flat array of records to the selectize load callback", function (assert) {
+        var done = assert.async(),
+            records = [{ email: "jsanchez@example.com", lastName: "Sanchez", firstName: "Jane" }],
+            capturedConfig,
+            selectizeStub = sinon.stub($.fn, "selectize", function (config) {
+                capturedConfig = config;
+                return this;
+            }),
+            searchStub = sinon.stub(SearchDelegate, "searchResults", function () {
+                return $.Deferred().resolve(records).promise();
+            });
+
+        try {
+            MappingUtils.setupSampleSearch(
+                $("<input>"),
+                { source: "system/hr/account" },
+                ["email", "lastName", "firstName"],
+                function () {}
+            );
+
+            assert.equal(capturedConfig.valueField, "email", "valueField is the first non-empty prop");
+
+            capturedConfig.load("Sanchez", function (options) {
+                // Regression test: options must be the flat array of records, not [[...]].
+                assert.deepEqual(options, records, "load callback receives a flat array of records");
+                done();
+            });
+        } finally {
+            selectizeStub.restore();
+            searchStub.restore();
+        }
+    });
+
+    QUnit.test("setupSampleSearch ignores props without a source (compacts valueField/searchField)", function (assert) {
+        var capturedConfig,
+            selectizeStub = sinon.stub($.fn, "selectize", function (config) {
+                capturedConfig = config;
+                return this;
+            });
+
+        try {
+            MappingUtils.setupSampleSearch(
+                $("<input>"),
+                { source: "managed/user" },
+                [undefined, "userName", "sn"],
+                function () {}
+            );
+
+            assert.equal(capturedConfig.valueField, "userName", "valueField falls back to first non-empty prop");
+            assert.deepEqual(capturedConfig.searchField, ["userName", "sn"], "searchField has no undefined entries");
+        } finally {
+            selectizeStub.restore();
+        }
+    });
 });

--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/delegates/SearchDelegate.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/delegates/SearchDelegate.js
@@ -30,12 +30,18 @@ define([
      * supplied props array starts with empty/undefined values (e.g. a mapping
      * whose first property has no "source"), an empty "_sortKeys=" must NOT be
      * emitted, otherwise the backend (CREST/IDM) returns an HTTP 500 error.
+     *
+     * In addition, "_sortKeys" is omitted for system resources ("system/..."),
+     * because many connectors (e.g. the CSV connector) do not support
+     * server-side sorting and would fail the whole query. Sample searches are
+     * capped at a handful of results anyway, so the sort order is not required.
      */
     obj.buildSearchUrl = function (resource, props, searchString, comparisonOperator, additionalQuery, maxPageSize) {
         var sortKey = _.find(props, function (p) { return !!p; }),
+            sortableResource = !/^\/?system\//.test(resource),
             url = "/" + resource + "?";
 
-        if (sortKey) {
+        if (sortKey && sortableResource) {
             url += "_sortKeys=" + sortKey + "&";
         }
 

--- a/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/delegates/SearchDelegate.js
+++ b/openidm-ui/openidm-ui-common/src/main/js/org/forgerock/openidm/ui/common/delegates/SearchDelegate.js
@@ -23,12 +23,35 @@ define([
 
     var obj = new AbstractDelegate(constants.host + "/" + constants.context);
 
+    /**
+     * Builds the search URL for a resource query.
+     *
+     * Note: only the first non-empty property is used for "_sortKeys". When the
+     * supplied props array starts with empty/undefined values (e.g. a mapping
+     * whose first property has no "source"), an empty "_sortKeys=" must NOT be
+     * emitted, otherwise the backend (CREST/IDM) returns an HTTP 500 error.
+     */
+    obj.buildSearchUrl = function (resource, props, searchString, comparisonOperator, additionalQuery, maxPageSize) {
+        var sortKey = _.find(props, function (p) { return !!p; }),
+            url = "/" + resource + "?";
+
+        if (sortKey) {
+            url += "_sortKeys=" + sortKey + "&";
+        }
+
+        // [a,b] => "a or (b)"; [a,b,c] => "a or (b or (c))"
+        url += "_pageSize=" + maxPageSize +
+               "&_queryFilter=" + obj.generateQueryFilter(props, searchString, additionalQuery, comparisonOperator);
+
+        return url;
+    };
+
     obj.searchResults = function (resource, props, searchString, comparisonOperator, additionalQuery) {
         var maxPageSize = 10;
 
         return this.serviceCall({
             "type": "GET",
-            "url":  "/" + resource + "?_sortKeys=" + props[0] + "&_pageSize=" + maxPageSize + "&_queryFilter=" + obj.generateQueryFilter(props, searchString, additionalQuery, comparisonOperator)// [a,b] => "a or (b)"; [a,b,c] => "a or (b or (c))"
+            "url":  obj.buildSearchUrl(resource, props, searchString, comparisonOperator, additionalQuery, maxPageSize)
         }).then(
             function (qry) {
                 return _.take(qry.result, maxPageSize);//we never want more than 10 results from search in case _pageSize does not work

--- a/openidm-ui/openidm-ui-common/src/test/qunit/tests/org/forgerock/openidm/ui/common/delegates/SearchDelegateTest.js
+++ b/openidm-ui/openidm-ui-common/src/test/qunit/tests/org/forgerock/openidm/ui/common/delegates/SearchDelegateTest.js
@@ -1,3 +1,18 @@
+/**
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Portions copyright 2026 3A Systems, LLC.
+ */
 define([
     "org/forgerock/openidm/ui/common/delegates/SearchDelegate"
 ], function (SearchDelegate) {
@@ -11,5 +26,34 @@ define([
 
         assert.equal(SearchDelegate.generateQueryFilter(props, search), '(userName sw "test" or (givenName sw "test" or (sn sw "test")))', "Basic Query Filter Generated");
         assert.equal(SearchDelegate.generateQueryFilter(props, search, additionalQuery, comparisonOperator), '((userName sw "test" or (givenName sw "test" or (sn sw "test"))) and (true))', "Complex Query Filter Generated");
+    });
+
+    QUnit.test("buildSearchUrl uses the first property as _sortKeys", function (assert) {
+        var url = SearchDelegate.buildSearchUrl("managed/user", ["userName", "sn"], "test", null, null, 10);
+
+        assert.equal(
+            url,
+            '/managed/user?_sortKeys=userName&_pageSize=10&_queryFilter=(userName sw "test" or (sn sw "test"))',
+            "_sortKeys is set to the first property"
+        );
+    });
+
+    QUnit.test("buildSearchUrl skips empty _sortKeys when the first property is missing (discussion #186)", function (assert) {
+        // Mapping whose first property has no "source" => leading undefined value.
+        var url = SearchDelegate.buildSearchUrl("managed/user", [undefined, "sn"], "test", null, null, 10);
+
+        assert.equal(url.indexOf("_sortKeys=&"), -1, "no empty _sortKeys= is emitted");
+        assert.equal(
+            url,
+            '/managed/user?_sortKeys=sn&_pageSize=10&_queryFilter=(sn sw "test")',
+            "_sortKeys falls back to the first non-empty property"
+        );
+    });
+
+    QUnit.test("buildSearchUrl omits _sortKeys entirely when no property is usable", function (assert) {
+        var url = SearchDelegate.buildSearchUrl("managed/user", [undefined, ""], "test", null, null, 10);
+
+        assert.equal(url.indexOf("_sortKeys"), -1, "no _sortKeys parameter is present at all");
+        assert.equal(url.indexOf("?_pageSize=10"), "/managed/user".length, "the query string starts directly with _pageSize");
     });
 });

--- a/openidm-ui/openidm-ui-common/src/test/qunit/tests/org/forgerock/openidm/ui/common/delegates/SearchDelegateTest.js
+++ b/openidm-ui/openidm-ui-common/src/test/qunit/tests/org/forgerock/openidm/ui/common/delegates/SearchDelegateTest.js
@@ -56,4 +56,15 @@ define([
         assert.equal(url.indexOf("_sortKeys"), -1, "no _sortKeys parameter is present at all");
         assert.equal(url.indexOf("?_pageSize=10"), "/managed/user".length, "the query string starts directly with _pageSize");
     });
+
+    QUnit.test("buildSearchUrl omits _sortKeys for system resources that may not support sorting", function (assert) {
+        var url = SearchDelegate.buildSearchUrl("system/hr/account", ["email", "lastName"], "Sanchez", null, null, 10);
+
+        assert.equal(url.indexOf("_sortKeys"), -1, "no _sortKeys parameter is sent to a system connector");
+        assert.equal(
+            url,
+            '/system/hr/account?_pageSize=10&_queryFilter=(email sw "Sanchez" or (lastName sw "Sanchez"))',
+            "system resource query has no _sortKeys but keeps the query filter"
+        );
+    });
 });


### PR DESCRIPTION
Fixes #186

## Summary

Using **Sample Source** (Properties tab) or **Single Record Reconciliation**
(Behaviors tab) returned an "Internal Error" with nothing meaningful in the logs
whenever the **first** property of a mapping had no `source` (e.g. a
transform-only / target-only property).

### Root cause

The admin UI built the autocomplete property list with
`_.pluck(mapping.properties, "source")` and took the first N elements without
checking whether they were defined. When the first property had no `source`, a
leading `undefined` ended up in the list and was passed down to
`SearchDelegate.searchResults`, which injected `props[0]` directly into the URL:

```
/managed/user?_sortKeys=&_pageSize=10&_queryFilter=...
```

The empty `_sortKeys=` is rejected by the CREST/IDM backend, producing an
HTTP 500 that surfaced only as a generic "Internal Error" (the failure was
logged via `console.error` only).

## Changes

### Defensive fix (lowest level)
- **`SearchDelegate.js`** — extracted URL construction into a testable
  `buildSearchUrl(...)`. `_sortKeys` is now derived from the **first non-empty**
  property; if no usable property exists, the `_sortKeys` parameter is omitted
  entirely. This guarantees an empty `_sortKeys=` can never be emitted again,
  even if a "leaky" property array is passed in the future.
  In addition, `_sortKeys` is **omitted for `system/...` resources**, because
  many connectors (e.g. the CSV connector used by the getting-started sample)
  do not support server-side sorting and would otherwise fail the whole sample
  query with an HTTP 500. Sample searches are capped at a few results, so the
  sort order is not required.

### Source fixes (UI views)
- **`SingleRecordReconciliationView.js`** — `setupSearch` now filters out empty
  `source` values before slicing the representative props.
- **`AttributesGridView.js`** — same filtering for the dynamic Sample Source.
- **`DataAssociationManagementView.js`** — same filtering for both `source` and
  `target` representative props.
- **`MappingUtils.js`** — `setupSampleSearch` compacts the property list and
  guards `valueField` / `searchField` against `undefined`.

> **Important — `_.first` vs `_.take` (lodash 3) regression.** The admin UI maps
> `underscore` → `lodash-3.10.1`. In lodash 3, `_.first(array, n)` ignores `n`
> and returns only the **first element**. An earlier iteration of the view fixes
> used `_.chain(...).pluck("source").filter(...).first(numRepresentativeProps)`,
> which therefore returned the single string `"email"` instead of an array. That
> string was then spread into characters (`["e","m","a","i","l"]`), producing a
> malformed query `(e sw "Sanchez" or (m sw "Sanchez" or ...))` that the system
> endpoint rejected with **HTTP 400**, leaving the dropdown empty. The final fix
> uses native `Array.prototype.filter().slice(0, n)` in all three views, which is
> library-agnostic and verified against a live getting-started instance.

### Tests
- **`SearchDelegateTest.js`** — added QUnit tests for `buildSearchUrl`:
  - `_sortKeys` set to the first property in the normal case;
  - leading `undefined` no longer produces an empty `_sortKeys=` and falls back
    to the first non-empty property (the #186 scenario);
  - `_sortKeys` omitted entirely when no property is usable;
  - `_sortKeys` omitted for `system/...` resources (CSV/connector sources).
- **`MappingUtilsTest.js`** — added QUnit tests for `setupSampleSearch`:
  - the selectize `load` callback receives a flat array of records;
  - `valueField`/`searchField` skip properties without a `source`.

## Affected files

| File | Change |
|------|--------|
| `openidm-ui/openidm-ui-common/.../delegates/SearchDelegate.js` | `buildSearchUrl` helper; never emit empty `_sortKeys=`; skip `_sortKeys` for `system/...` resources |
| `openidm-ui/openidm-ui-admin/.../mapping/behaviors/SingleRecordReconciliationView.js` | Filter empty `source` in `setupSearch` |
| `openidm-ui/openidm-ui-admin/.../mapping/properties/AttributesGridView.js` | Filter empty `source` for Sample Source |
| `openidm-ui/openidm-ui-admin/.../mapping/association/DataAssociationManagementView.js` | Filter empty `source`/`target` |
| `openidm-ui/openidm-ui-admin/.../mapping/util/MappingUtils.js` | Compact props; guard `valueField`/`searchField`; pass flat array to selectize `load` |
| `openidm-ui/openidm-ui-common/.../test/.../SearchDelegateTest.js` | New tests for `buildSearchUrl` |
| `openidm-ui/openidm-ui-admin/.../test/.../MappingUtilsTest.js` | New tests for `setupSampleSearch` |

## How to test

1. Create a mapping whose **first** property has no `source` (transform/target-only).
2. Open the **Properties** tab and use **Sample Source** — autocomplete works,
   no "Internal Error".
3. Open the **Behaviors** tab and use **Single Record Reconciliation** — sample
   search works as expected.
4. Run the UI QUnit suite — `Search Delegate Tests` pass, including the new
   `buildSearchUrl` cases.
5. Run the getting-started Playwright suite
   (`OPENIDM_SAMPLE=samples/getting-started`) — the *Sample Source 'Sanchez'*
   test passes: typing `Sanchez` shows the *Jane Sanchez* dropdown option and
   selecting it populates the preview (the `system/hr/account` CSV connector no
   longer fails on `_sortKeys`).