### PR TITLE
Modernizes the OpenIDM Docker images and broadens their multi-architecture build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,7 @@ jobs:
         run: |
           docker run --rm -it -d --memory="1g" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
+          docker logs test
   build-docker-alpine:
     runs-on: 'ubuntu-latest'
     services:
@@ -361,3 +362,4 @@ jobs:
         run: |
           docker run --rm -it -d --memory="1g" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-alpine
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
+          docker logs test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x #, linux/arm/v7
+          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x, linux/riscv64 #, linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -352,7 +352,7 @@ jobs:
           file: ./Dockerfile-alpine
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le, linux/riscv64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,16 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 name: Release
 
 on:
@@ -153,7 +166,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             VERSION=${{ github.event.inputs.releaseVersion }}
-          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x #, linux/arm/v7
+          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x, linux/riscv64 #, linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -201,7 +214,7 @@ jobs:
           file: ./Dockerfile-alpine
           build-args: |
             VERSION=${{ github.event.inputs.releaseVersion }}
-          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le, linux/riscv64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2024-2026 3A Systems, LLC.
-FROM eclipse-temurin:25-jre-jammy
+FROM eclipse-temurin:25-jre-noble
 
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -24,7 +24,7 @@ WORKDIR /opt
 
 #COPY openidm-zip/target/openidm-*.zip ./
 
-RUN apk add --update --no-cache --virtual builddeps curl unzip libc6-compat openjdk17 \
+RUN apk add --update --no-cache --virtual builddeps curl unzip libc6-compat openjdk25-jre \
  && apk upgrade --update --no-cache \
  && apk add bash \
  && apk update  \


### PR DESCRIPTION
## Summary

Modernizes the OpenIDM Docker images and broadens their multi-architecture build matrix, and improves CI diagnostics for the Docker smoke tests. Ported from [OpenIdentityPlatform/OpenDJ#655](https://github.com/OpenIdentityPlatform/OpenDJ/pull/655), adapted to OpenIDM's Java 17+ requirement.

- **Ubuntu image** (`Dockerfile`): switch the base image from `eclipse-temurin:25-jre-jammy` to `eclipse-temurin:25-jre-noble` (Ubuntu 22.04 → 24.04).
- **Alpine image** (`Dockerfile-alpine`): bump the JDK from `openjdk17` to `openjdk25-jre`, aligning the Alpine runtime with the Ubuntu JRE 25 image and enabling `linux/riscv64`.
- **Workflows** (`build.yml`, `release.yml`): add `linux/riscv64` to both the Ubuntu and Alpine docker build platforms.
- **CI diagnostics** (`build.yml`): print `docker logs test` at the end of both `Docker test` steps so container output is captured on failed health checks.
- **Housekeeping** (`release.yml`): add the CDDL license header.

## Platform coverage

| Image | Platforms |
|-------|-----------|
| Ubuntu / Noble (`Dockerfile`) | `linux/amd64`, `linux/arm64/8`, `linux/ppc64le`, `linux/s390x`, `linux/riscv64` |
| Alpine (`Dockerfile-alpine`) | `linux/amd64`, `linux/arm64/8`, `linux/s390x`, `linux/ppc64le`, `linux/riscv64` |

## Why `linux/386` is not included

Unlike OpenDJ (which supports Java 11–25), OpenIDM is compiled for **Java 17+** (`maven.compiler.target=17` in the root `pom.xml`). Alpine ships **no Java 17+ build for 32-bit x86 (`linux/386`)** — only `openjdk11` — so a `linux/386` image could not run OpenIDM. It is therefore intentionally excluded, and no conditional/per-architecture JDK selection is needed: a single `openjdk25-jre` covers every target architecture.

## Notes

- `linux/arm/v6` and `linux/arm/v7` remain excluded: neither Alpine nor `eclipse-temurin` publishes an OpenJDK for those architectures.
- The docker build steps use `continue-on-error: true`, so an architecture without a published base/JDK won't fail the whole job.

## Testing

- `build-docker` (Ubuntu/Noble) and `build-docker-alpine` jobs build across the listed platforms, including the existing "Docker test" smoke tests (now with container logs printed).
