### PR TITLE
Add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 3A Systems, LLC.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+  schedule:
+    - cron: '27 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - '**/src/test/**'
+              - '**/src/it/**'
+              - '**/*.min.js'
+              - '**/node_modules/**'
+              - '**/target/**'
+              - '**/test-output/**'
+              - 'openidm-ui/extlib/**'
+              - 'e2e/**'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds a GitHub Actions **CodeQL** workflow for automated security/quality scanning, adapted from the OpenAM setup.

### What it does
- Analyzes **java-kotlin**, **javascript-typescript**, and **actions** (`build-mode: none`).
- Triggers on push/PR to `master`, a weekly schedule (Mon 03:27), and manual `workflow_dispatch`.
- Uses the **security-and-quality** query suite.

### OpenIDM-specific tuning
- Dropped `csharp` from the language matrix — no C# in this repo.
- `paths-ignore` tailored to OpenIDM's layout: `**/src/test/**`, `**/src/it/**`, `**/*.min.js`, `**/node_modules/**`, `**/target/**` (Maven build output), `openidm-ui/extlib/**` (vendored JS), and `e2e/**` (Playwright).

New file carries the standard CDDL header.
