### PR TITLE
CI: trim build matrix on macOS/Windows and add workflow concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,28 @@ on:
   push:
     branches: [ 'sustaining/6.3.x','master', 'issues/**', 'features/**' ]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ 'ubuntu-latest' ]
         java: [ '17', '21', '25', '26' ]
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        # macOS and Windows runners are the slowest and scarcest in CI, so only
+        # smoke-test the minimum (17) and maximum (26) supported JDKs on them.
+        # Ubuntu keeps the full JDK matrix above.
+        include:
+          - os: 'macos-latest'
+            java: '17'
+          - os: 'macos-latest'
+            java: '26'
+          - os: 'windows-latest'
+            java: '17'
+          - os: 'windows-latest'
+            java: '26'
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,16 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 name: Package/Deploy
 
 on:
@@ -6,6 +19,9 @@ on:
     branches: [ 'sustaining/6.3.x','master' ]
     workflows: ["Build","Release"]
     types: [completed]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 jobs:
   deploy-maven:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,16 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 name: Release
 
 on:
@@ -11,6 +24,9 @@ on:
         description: "Default version to use for new local working copy."
         required: true
         default: "X.Y.Z-SNAPSHOT"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release-maven:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Analogous to OpenICF [#98](https://github.com/OpenIdentityPlatform/OpenICF/pull/98).

## Trim build matrix
`build.yml` ran a full 4×3 matrix (JDK 17/21/25/26 × Ubuntu/macOS/Windows = 12 jobs). macOS and Windows runners are the slowest and scarcest in CI and rarely surface OS-specific issues beyond the JDK edges, so:

- Ubuntu keeps the full JDK matrix (17, 21, 25, 26).
- macOS and Windows now smoke-test only the minimum (17) and maximum (26) JDKs via `include`.
- Total jobs: **12 → 8**.

The `ui-smoke-tests` job is unaffected: it downloads the `ubuntu-latest-17` and `ubuntu-latest-26` artifacts, both of which are still produced by the Ubuntu matrix.

## Workflow concurrency
Added `concurrency` groups keyed on `${{ github.workflow }}-${{ github.ref }}` (deploy uses `head_branch`, since it is triggered by `workflow_run`):

- `build.yml`: `cancel-in-progress: true` — a new push/PR cancels a superseded in-flight build.
- `release.yml` / `deploy.yml`: `cancel-in-progress: false` — overlapping runs queue instead of being interrupted, protecting Maven Central publishing / GitHub releases.

Also adds the standard CDDL header to `deploy.yml` and `release.yml` (they had none).