### PR TITLE
Enable strict Javadoc doclint (all,-missing) and fix all doclint issues

### DIFF
--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectType.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectType.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -32,7 +33,7 @@ import java.util.List;
  * A single connector configuration objectType, contained in {@link CustomConfiguration}.
  *
  * Given a JSON configuration such as:
- * <pre><blockquote>
+ * <pre>
  *      "objectTypes" : [
  *          {
  *              "name" : "group",
@@ -66,7 +67,7 @@ import java.util.List;
  *              ]
  *          }
  *      ]
- * </blockquote></pre>
+ * </pre>
  * this object represents a single objectType array element.
  */
 public class CustomObjectType extends CustomBaseObject {

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypeProperty.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypeProperty.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -32,7 +33,7 @@ import java.util.*;
  * A single connector objectType property, contained in {@link CustomObjectType}.
  *
  * Given a JSON configuration such as:
- * <pre><blockquote>
+ * <pre>
  *      "properties" : [
  *          {
  *              "name" : "name",
@@ -57,7 +58,7 @@ import java.util.*;
  *              ...
  *          }
  *      ]
- * </blockquote></pre>
+ * </pre>
  * this object represents a single properties array element.
  */
 public class CustomObjectTypeProperty extends CustomBaseObject {

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyFlag.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyFlag.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -31,12 +32,12 @@ import java.util.List;
  * A single objectType property flag, contained in {@link CustomObjectTypeProperty}.
  *
  * Represented in a JSON configuration list as:
- * <pre><blockquote>
+ * <pre>
  *      "flags" : [
  *          "NOT_READABLE",
  *          "NOT_RETURNED_BY_DEFAULT"
  *      ],
- * </blockquote></pre>
+ * </pre>
  */
 public class CustomObjectTypePropertyFlag extends CustomBaseObject {
     /**

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyItemProperty.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyItemProperty.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -31,12 +32,12 @@ import java.util.List;
  * A single property of an objectType item, contained in {@link CustomObjectTypePropertyItems}.
  *
  * Represented in JSON as:
- * <pre><blockquote>
+ * <pre>
  *      {
  *          "name" : "uid",
  *          "type" : "string"
  *      }
- * </blockquote></pre>
+ * </pre>
  */
 public class CustomObjectTypePropertyItemProperty extends CustomBaseObject {
     /**

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyItems.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomObjectTypePropertyItems.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -33,7 +34,7 @@ import java.util.List;
  * A single connector configuration objectType, contained in {@link CustomObjectTypeProperty}.
  *
  * Represented in a JSON configuration as:
- * <pre><blockquote>
+ * <pre>
  *      {
  *          "type" : "object",
  *          "nativeType" : "object",
@@ -42,7 +43,7 @@ import java.util.List;
  *              "type" : "string"
  *          }]
  *      }
- * </blockquote></pre>
+ * </pre>
  */
 public class CustomObjectTypePropertyItems extends CustomBaseObject {
 

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomProperty.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/CustomProperty.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -34,7 +35,7 @@ import java.util.List;
  * A single connector configuration property, contained in {@link CustomConfiguration}.
  *
  * The JSON configuration might contain something like the following:
- * <pre><blockquote>
+ * <pre>
  * "properties" : [
  *      {
  *          "order" : 0,
@@ -58,7 +59,7 @@ import java.util.List;
  *          "group" : "default"
  *      }
  *  ]
- * </blockquote></pre>
+ * </pre>
  *
  * This object represents a single property in the list above.  These properties define the connector's
  * configuration properties and are the data source for generating the code to support connector metadata

--- a/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/ProvidedProperty.java
+++ b/custom-scripted-connector-bundler/src/main/java/org/forgerock/openidm/tools/scriptedbundler/ProvidedProperty.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -34,7 +35,7 @@ import java.util.List;
  * A single connector configuration property, contained in {@link org.forgerock.openidm.tools.scriptedbundler.CustomConfiguration}.
  *
  * The JSON configuration might contain something like the following:
- * <pre><blockquote>
+ * <pre>
  * "providedProperties" : [
  *      {
  *          "name" : "FirstProperty",
@@ -46,7 +47,7 @@ import java.util.List;
  *          "type" : "Float"
  *      }
  *  ]
- * </blockquote></pre>
+ * </pre>
  *
  * This object represents a single property in the list above.  These properties populate values for the properties
  * defined by default in the connector's base configuration class.  For example, the ScriptedSQLConfiguration class

--- a/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditLogger.java
+++ b/openidm-audit/src/main/java/org/forgerock/openidm/audit/impl/AuditLogger.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -109,7 +110,6 @@ public interface AuditLogger {
      * @param handler the {@link QueryResourceHandler} object.
      * @param type the type of audit log entries to query
      * @param formatted whether to format the results.
-     * @return the query result object.
      * @throws NotFoundException if the specified object could not be found.
      * @throws ForbiddenException if access to the object or the specified query is forbidden.
      */

--- a/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/oauth/OAuthModule.java
+++ b/openidm-authnfilter/src/main/java/org/forgerock/openidm/auth/modules/oauth/OAuthModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.auth.modules.oauth;
 
@@ -190,7 +191,6 @@ public class OAuthModule implements AsyncServerAuthModule {
      * @param messageInfo {@inheritDoc}
      * @param subject {@inheritDoc}
      * @return {@inheritDoc}
-     * @throws AuthException {@inheritDoc}
      */
     @Override
     public Promise<AuthStatus, AuthenticationException> secureResponse(MessageInfoContext messageInfo,
@@ -203,7 +203,6 @@ public class OAuthModule implements AsyncServerAuthModule {
      *
      * @param messageInfo {@inheritDoc}
      * @param subject {@inheritDoc}
-     * @throws AuthException {@inheritDoc}
      */
     @Override
     public Promise<Void, AuthenticationException> cleanSubject(MessageInfoContext messageInfo, Subject subject) {

--- a/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/manage/ConfigObjectService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2024 3A Systems LLC.
+ * Portions Copyrighted 2024-2026 3A Systems LLC.
  */
 
 
@@ -313,7 +313,7 @@ public class ConfigObjectService implements RequestHandler, ClusterEventListener
 
     /**
      * Creates a new object in the object set.
-     * <p/>
+     * <p>
      * This method sets the {@code _id} property to the assigned identifier for the object,
      * and the {@code _rev} property to the revised object version (For optimistic concurrency)
      *

--- a/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/ConfigPersisterMarker.java
+++ b/openidm-config/src/main/java/org/forgerock/openidm/config/persistence/ConfigPersisterMarker.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -37,7 +38,7 @@ public interface ConfigPersisterMarker {
      * Notifies the extension when the system determined that 
      * all necessary services are ready, and checks if the 
      * extension itself is ready
-     * @throws an exception if the extension could not initiate
+     * @throws BootstrapFailure if the extension could not initiate
      */
     void checkReady() throws BootstrapFailure;
 }

--- a/openidm-core/src/main/java/org/forgerock/openidm/internal/metadata/ConfigMeta.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/internal/metadata/ConfigMeta.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.internal.metadata;
 
@@ -46,9 +47,6 @@ public class ConfigMeta implements MetaDataProvider {
      * JsonPointer("/")); properties = Collections.unmodifiableList(p); }
      */
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) throws WaitForMetaData, NotConfiguration {
         if (ManagedObjectService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -58,9 +56,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
 //    @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This instance won't be updated

--- a/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipProvider.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/managed/RelationshipProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.managed;
 
@@ -165,7 +166,7 @@ public abstract class RelationshipProvider {
      * Returns a Function to format a resource from the repository to that expected by the provider consumer. First
      * object properties are removed and {@code secondId} (or {@code firstId} if it's a reverse relationship)
      * will be converted to {@code _ref}
-     * <p/>
+     * <p>
      * This will convert repo resources in the format of:
      * <pre>
      *     {
@@ -177,7 +178,7 @@ public abstract class RelationshipProvider {
      *         "properties": { ... }
      *     }
      * </pre>
-     * <p/>
+     * <p>
      * To a provider response format of:
      *
      * <pre>

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/PendingActionContext.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/PendingActionContext.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.sync;
 
@@ -78,8 +79,6 @@ public class PendingActionContext extends AbstractContext {
     
     /**
      * Clears pending link data, sets pending to false.
-     *
-     * @return this object's name
      */
     public void clear() {
         data.remove(ATTR_ACTION_DATA);

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/ReconContext.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/ReconContext.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.sync;
@@ -37,7 +38,7 @@ public class ReconContext extends AbstractContext {
      * Create a new recon context from an existing (parent) context.
      *
      * @param parent the parent server context
-     * @param trigger the trigger source
+     * @param mapping the name of the mapping associated with the reconciliation
      */
     public ReconContext(final Context parent, String mapping) {
         super(checkNotNull(parent, "Cannot instantiate ReconContext with null parent Context"), CONTEXT_NAME);

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeBase.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeBase.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -85,7 +86,7 @@ public abstract class ReconTypeBase implements ReconTypeHandler {
     /**
      * A constructor.
      * 
-     * @param reconContext a {@link RconciliationContext} object.
+     * @param reconContext a {@link ReconciliationContext} object.
      * @param defaultRunTargetPhase a boolean indicating if target phase should be run.
      */
     public ReconTypeBase(ReconciliationContext reconContext, boolean defaultRunTargetPhase) {
@@ -203,7 +204,7 @@ public abstract class ReconTypeBase implements ReconTypeHandler {
      * sensitive fashion, or if false it populates as lower case only
      * @param pageSize the page size if paging
      * @param pagingCookie the cookie to use if paging, null if first page
-     * @param reconContext the {@link RconciliationContext} object associated with this recon
+     * @param reconContext the {@link ReconciliationContext} object associated with this recon
      * @param querySide an indicator for which side of a reconciliation (source or target) a query is for
      * @return a {@link ReconQueryResult} containing the collection of (unqualified) ids
      * @throws SynchronizationException if retrieving or processing the ids failed
@@ -309,21 +310,12 @@ public abstract class ReconTypeBase implements ReconTypeHandler {
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public abstract ReconQueryResult querySource(int pageSize, String pagingCookie) throws SynchronizationException;
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public abstract ResultIterable queryTarget() throws SynchronizationException;
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public abstract JsonValue getReconParameters();
 }

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeByQuery.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconTypeByQuery.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -50,8 +51,7 @@ public class ReconTypeByQuery extends ReconTypeBase {
     /**
      * A constructor.
      * 
-     * @param reconContext a {@link RconciliationContext} object.
-     * @throws BadRequestException
+     * @param reconContext a {@link ReconciliationContext} object.
      */
     public ReconTypeByQuery(ReconciliationContext reconContext) {
         super(reconContext, DEFAULT_RUN_TARGET_PHASE);

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconciliationStatistic.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ReconciliationStatistic.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -269,7 +270,7 @@ public class ReconciliationStatistic {
     }
 
     /**
-     * @return the duration, in milliseconds, of an event defined by a {@code startTime} and an {@code endTime}
+     * Returns the duration, in milliseconds, of an event defined by a {@code startTime} and an {@code endTime}.
      *
      * @param startTime the start time
      * @param endTime the end time

--- a/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ResultEntry.java
+++ b/openidm-core/src/main/java/org/forgerock/openidm/sync/impl/ResultEntry.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.sync.impl;
 
@@ -25,8 +26,8 @@ public class ResultEntry {
     private final JsonValue value;
     
     /** 
-     * @param The normalized identifier
-     * @param optional pre-queried value, or null if value not pre-queried
+     * @param id The normalized identifier
+     * @param value optional pre-queried value, or null if value not pre-queried
      */
     public ResultEntry(String id, JsonValue value) {
         this.id = id;

--- a/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/metadata/ConfigMeta.java
+++ b/openidm-customendpoint/src/main/java/org/forgerock/openidm/customendpoint/impl/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -51,9 +52,6 @@ public class ConfigMeta implements MetaDataProvider {
      */
     final static Logger logger = LoggerFactory.getLogger(ConfigMeta.class);
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) throws WaitForMetaData {
         if (EndpointsService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -74,9 +72,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This newBuilder won't be updated

--- a/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/metadata/ConfigMeta.java
+++ b/openidm-external-email/src/main/java/org/forgerock/openidm/external/email/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -55,9 +56,6 @@ public class ConfigMeta implements MetaDataProvider {
         propertiesToEncrypt.put(EmailServiceImpl.PID, props);
     }
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias, JsonValue config) {
         if (propertiesToEncrypt.containsKey(pidOrFactory)) {
             return propertiesToEncrypt.get(pidOrFactory);
@@ -65,9 +63,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         this.callback = callback;

--- a/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/impl/ProviderConfigMapper.java
+++ b/openidm-identity-provider/src/main/java/org/forgerock/openidm/idp/impl/ProviderConfigMapper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.idp.impl;
 
@@ -73,14 +74,14 @@ public class ProviderConfigMapper {
      * Converts a {@link ProviderConfig} to {@link JsonValue}.
      *
      * @param config of {@link ProviderConfig} to convert to {@link JsonValue}
-     * @return {@link ProviderConfig as {@link JsonValue}}
+     * @return {@link ProviderConfig} as {@link JsonValue}
      */
     public static JsonValue toJsonValue(ProviderConfig config) {
         return toJsonValue.apply(config);
     }
 
     /**
-     * Converts a List of {@Link ProviderConfig} to {@link JsonValue}.
+     * Converts a List of {@link ProviderConfig} to {@link JsonValue}.
      *
      * @param configList of {@link ProviderConfig}
      * @return {@link ProviderConfig} list as a {@link JsonValue}

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/DatabaseInfoResourceProvider.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/health/DatabaseInfoResourceProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.info.health;
@@ -47,7 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gets BoneCP usage statistics from the {@link com.jolbox.bonecp.StatisticsMBean StatisticsMBean}.
+ * Gets BoneCP usage statistics from the {@code StatisticsMBean}.
  */
 @SingletonProvider(@Handler(
         id = "databaseInfoResourceProvider:0",

--- a/openidm-infoservice/src/main/java/org/forgerock/openidm/info/metadata/ConfigMeta.java
+++ b/openidm-infoservice/src/main/java/org/forgerock/openidm/info/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -49,9 +50,6 @@ public class ConfigMeta implements MetaDataProvider {
      */
     final static Logger logger = LoggerFactory.getLogger(ConfigMeta.class);
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) throws WaitForMetaData, NotConfiguration {
         if (HealthService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -65,9 +63,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This metadata won't be updated

--- a/openidm-jetty-fragment/src/main/java/org/forgerock/openidm/jetty/JettyErrorHandler.java
+++ b/openidm-jetty-fragment/src/main/java/org/forgerock/openidm/jetty/JettyErrorHandler.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 
 package org.forgerock.openidm.jetty;
@@ -45,7 +45,6 @@ public class JettyErrorHandler extends org.eclipse.jetty.ee10.servlet.ErrorHandl
     /**
      * Handles Jetty errors originating from HTTP requests. Add the following entry to {@code jetty.xml} or directly
      * to an {@code org.eclipse.jetty.server.Server} instance.
-     * <p>
      * <pre>
      * &lt;Configure id="Server" class="org.eclipse.jetty.server.Server">
      *   ...
@@ -58,8 +57,6 @@ public class JettyErrorHandler extends org.eclipse.jetty.ee10.servlet.ErrorHandl
      * &lt;/Configure>
      * </pre>
      *
-     * @param target The target of the request, which is either a URI, name, or {@code null}.
-     * @param baseRequest Jetty HTTP request
      * @param request Servlet HTTP request
      * @param response Servlet HTTP response
      * @throws IOException I/O error

--- a/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/ComparableVersion.java
+++ b/openidm-maintenance/src/main/java/org/forgerock/openidm/maintenance/upgrade/ComparableVersion.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.maintenance.upgrade;
@@ -51,7 +53,7 @@ import java.util.Stack;
  *     Unknown qualifiers are considered after known qualifiers, with lexical order (always case insensitive),
  *   </li>
  * <li>a dash usually precedes a qualifier, and is always less important than something preceded with a dot.</li>
- * </ul></p>
+ * </ul>
  *
  * @see <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
  * @author <a href="mailto:kenney@apache.org">Kenney Westerhof</a>

--- a/openidm-policy/src/main/java/org/forgerock/openidm/policy/metadata/ConfigMeta.java
+++ b/openidm-policy/src/main/java/org/forgerock/openidm/policy/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -48,9 +49,6 @@ public class ConfigMeta implements MetaDataProvider {
      */
     final static Logger logger = LoggerFactory.getLogger(ConfigMeta.class);
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) throws WaitForMetaData, NotConfiguration {
         if (PolicyService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -60,9 +58,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This metadata won't be updated

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/ConnectorInfoProvider.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/ConnectorInfoProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.provisioner.openicf;
 
@@ -66,7 +67,6 @@ public interface ConnectorInfoProvider {
     /**
      * Create a new configuration object from the {@code configuration}
      * parameter.
-     * <p/>
      *
      * @param configuration
      * @return

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/ConnectorReference.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/ConnectorReference.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -28,7 +29,7 @@ import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.framework.api.ConnectorKey;
 
 /**
- * ConnectorReference holds the required {@ConnectorKey} value to
+ * ConnectorReference holds the required {@link ConnectorKey} value to
  * find the correct connector in the
  * {@link org.identityconnectors.framework.api.ConnectorInfoManager}. The
  * {@code getConnectorHost} is the key for the ConnectorInfoManager newBuilder.

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/OperationHelper.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/OperationHelper.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -50,10 +51,10 @@ public interface OperationHelper {
      *
      * @param operation
      * @return if {@code denied} is true and the {@code onDeny} equals
-     *         {@link org.forgerock.openidm.provisioner.openicf.commons.OperationOptionInfoHelper.OnDenyAction#DO_NOTHING}
+     *         {@code OperationOptionInfoHelper.OnDenyAction.DO_NOTHING}
      *         returns false else true
      * @throws ResourceException if {@code denied} is true and the {@code onDeny} equals
-     *                            {@link org.forgerock.openidm.provisioner.openicf.commons.OperationOptionInfoHelper.OnDenyAction#THROW_EXCEPTION}
+     *                            {@code OperationOptionInfoHelper.OnDenyAction.THROW_EXCEPTION}
      */
     boolean isOperationPermitted(Class<? extends APIOperation> operation) throws ResourceException;
 
@@ -78,7 +79,7 @@ public interface OperationHelper {
 
     /**
      * Generate the fully qualified id from unqualified object {@link Uid}
-     * <p/>
+     * <p>
      * The result id will be system/{@code [endSystemName]}/{@code [objectType]}/{@code [escapedObjectId]}
      *
      * @param uid original un escaped unique identifier of the object
@@ -97,8 +98,6 @@ public interface OperationHelper {
     /**
      * Build new {@code Filter} instance form the {@code query} and {@code params} values.
      *
-     * @param query
-     * @param params
      * @return
      * @throws Exception
      */
@@ -110,7 +109,7 @@ public interface OperationHelper {
 
     /**
      * Build a new Map object from the {@code source} object.
-     * <p/>
+     * <p>
      * This class uses the embedded schema to convert the {@code source}.
      *
      * @param source

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/AttributeInfoHelper.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/AttributeInfoHelper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.provisioner.openicf.commons;
@@ -176,9 +177,10 @@ public class AttributeInfoHelper {
 
     /**
      * Get the Java Class for the {@code type} value in the schema.
-     * <p/>
+     * <p>
      * The Default mapping:
      * <table>
+     * <caption>Default JSON to Java type mapping</caption>
      * <tr><td>JSON Type</td><td>Java Type</td></tr>
      * <tr><td>any</td><td>{@link Object}</td></tr>
      * <tr><td>boolean</td><td>{@link Boolean}</td></tr>
@@ -188,7 +190,6 @@ public class AttributeInfoHelper {
      * <tr><td>number</td><td>{@link Number}</td></tr>
      * <tr><td>object</td><td>{@link Map}</td></tr>
      * <tr><td>string</td><td>{@link String}</td></tr>
-     * </tr>
      * </table>
      *
      * @return
@@ -227,13 +228,12 @@ public class AttributeInfoHelper {
     }
 
     /**
-     * The {@link org.forgerock.json.resource.QueryFilterVisitor} use this
+     * The {@code org.forgerock.json.resource.QueryFilterVisitor} use this
      * method to convert the string value to {@link Attribute} use in
      * {@link org.identityconnectors.framework.common.objects.filter.Filter}
-     * 
+     *
      * @param source
      * @return
-     * @throws Exception
      */
     public Attribute build(Object source) {
         return build(attributeInfo, source);
@@ -312,7 +312,7 @@ public class AttributeInfoHelper {
      * @throws IOException
      * @throws IllegalArgumentException
      *             if the type is not on the supported list.
-     * @see {@link org.identityconnectors.framework.common.FrameworkUtil#checkOperationOptionType(Class)}
+     * @see org.identityconnectors.framework.common.FrameworkUtil#checkOperationOptionType(Class)
      */
     public void build(OperationOptionsBuilder builder, Object value) throws IOException {
         if (value == null || (value instanceof JsonValue && !((JsonValue) value).isNull())) {

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ConnectorUtil.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ConnectorUtil.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2016 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -191,29 +192,30 @@ public class ConnectorUtil {
 
     /**
      * Get the Java Class for the {@code type} value in the schema.
-     * <p/>
+     * <p>
      * The Default mapping:
      * <table>
+     * <caption>Default type name to Java class mapping</caption>
      * <tr><td>any</td><td>{@link Object}</td></tr>
      * <tr><td>JAVA_TYPE_BIGDECIMAL</td><td>{@link BigDecimal}</td></tr>
      * <tr><td>JAVA_TYPE_BIGINTEGER</td><td>{@link BigInteger}</td></tr>
-     * <tr><td>JAVA_TYPE_PRIMITIVE_BOOLEAN</td><td>{@link boolean}</td></tr>
+     * <tr><td>JAVA_TYPE_PRIMITIVE_BOOLEAN</td><td>{@code boolean}</td></tr>
      * <tr><td>boolean</td><td>{@link Boolean}</td></tr>
-     * <tr><td>JAVA_TYPE_BYTE_ARRAY</td><td>{@link byte[]}</td></tr>
-     * <tr><td>JAVA_TYPE_CHAR</td><td>{@link char}</td></tr>
+     * <tr><td>JAVA_TYPE_BYTE_ARRAY</td><td>{@code byte[]}</td></tr>
+     * <tr><td>JAVA_TYPE_CHAR</td><td>{@code char}</td></tr>
      * <tr><td>JAVA_TYPE_CHARACTER</td><td>{@link Character}</td></tr>
      * <tr><td>JAVA_TYPE_DATE</td><td>{@link String}</td></tr>
-     * <tr><td>JAVA_TYPE_PRIMITIVE_DOUBLE</td><td>{@link double}</td></tr>
+     * <tr><td>JAVA_TYPE_PRIMITIVE_DOUBLE</td><td>{@code double}</td></tr>
      * <tr><td>JAVA_TYPE_DOUBLE</td><td>{@link Double}</td></tr>
      * <tr><td>JAVA_TYPE_FILE</td><td>{@link File}</td></tr>
-     * <tr><td>JAVA_TYPE_PRIMITIVE_FLOAT</td><td>{@link float}</td></tr>
+     * <tr><td>JAVA_TYPE_PRIMITIVE_FLOAT</td><td>{@code float}</td></tr>
      * <tr><td>JAVA_TYPE_FLOAT</td><td>{@link Float}</td></tr>
      * <tr><td>JAVA_TYPE_GUARDEDBYTEARRAY</td><td>{@link GuardedByteArray}</td></tr>
      * <tr><td>JAVA_TYPE_GUARDEDSTRING</td><td>{@link GuardedString}</td></tr>
-     * <tr><td>JAVA_TYPE_INT</td><td>{@link int}</td></tr>
+     * <tr><td>JAVA_TYPE_INT</td><td>{@code int}</td></tr>
      * <tr><td>integer</td><td>{@link Integer}</td></tr>
      * <tr><td>array</td><td>{@link List}</td></tr>
-     * <tr><td>JAVA_TYPE_PRIMITIVE_LONG</td><td>{@link long}</td></tr>
+     * <tr><td>JAVA_TYPE_PRIMITIVE_LONG</td><td>{@code long}</td></tr>
      * <tr><td>JAVA_TYPE_LONG</td><td>{@link Long}</td></tr>
      * <tr><td>JAVA_TYPE_NAME</td><td>{@link Name}</td></tr>
      * <tr><td>null</td><td>{@code null}</td></tr>
@@ -236,7 +238,7 @@ public class ConnectorUtil {
 
     /**
      * Find the string code of the given {@code clazz}.
-     * <p/>
+     * <p>
      * Encodes the {@link Class} to String code
      *
      * @param clazz
@@ -254,7 +256,7 @@ public class ConnectorUtil {
 
     /**
      * Find the proper target simple class type for the source type.
-     * <p/>
+     * <p>
      * JSON schema has predefined types abd this method maps the {@code clazz} Class to proper representation
      *
      * @param clazz
@@ -279,7 +281,6 @@ public class ConnectorUtil {
 
     /**
      * Convert the {@link ObjectPoolConfiguration} to simple Map.
-     * <p/>
      *
      * @param info
      * @return
@@ -316,7 +317,6 @@ public class ConnectorUtil {
 
     /**
      * Convert the {@link ObjectPoolConfiguration} to simple Map.
-     * <p/>
      *
      * @param info
      * @return
@@ -520,7 +520,7 @@ public class ConnectorUtil {
 
     /**
      * Convert the {@link ConnectorKey} into a Map.
-     * <p/>
+     * <p>
      * The connector key is saved in a JSON object and this method converts it to simple Map.
      *
      * @param info
@@ -536,7 +536,7 @@ public class ConnectorUtil {
 
     /**
      * Create a new {@link ConnectorKey} newBuilder form the {@code configuration} object.
-     * <p/>
+     * <p>
      * The Configuration object MUST contain the three required String properties.
      * <ul>
      * <li>bundleName</li>
@@ -547,7 +547,6 @@ public class ConnectorUtil {
      * @param configuration
      * @return new newBuilder of {@link ConnectorKey}
      * @throws IllegalArgumentException when one of the three required parameter is null.
-     * @throws IOException              when the property value can not be converted to String.
      */
     public static ConnectorKey getConnectorKey(JsonValue configuration) throws JsonValueException {
         String bundleName = configuration.get(OPENICF_BUNDLENAME).asString();
@@ -753,7 +752,7 @@ public class ConnectorUtil {
 
     /**
      * Build a {@link Map} from the given {@link org.identityconnectors.framework.common.objects.AttributeInfo}
-     * <p/>
+     * <p>
      * The result will look like this:
      * {
      * "type"    : "number",
@@ -825,7 +824,7 @@ public class ConnectorUtil {
 
     /**
      * Create a new {@link SyncToken} from the input.
-     * <p/>
+     * <p>
      * The source object:
      * {@code
      * {
@@ -852,7 +851,7 @@ public class ConnectorUtil {
 
     /**
      * Create a new Map from the given {@link SyncToken}.
-     * <p/>
+     * <p>
      * The target object:
      * {@code
      * {
@@ -885,14 +884,12 @@ public class ConnectorUtil {
 
     /**
      * Coerce the {@code source} object to an object of {@code clazz} type.
-     * <p/>
      *
      * @param <T>
      * @param source
      * @param clazz
      * @return
      * @throws NumberFormatException
-     * @throws URISyntaxException
      * @throws UnsupportedOperationException
      */
     @SuppressWarnings("unchecked")

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ObjectClassInfoHelper.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/ObjectClassInfoHelper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.provisioner.openicf.commons;
@@ -115,7 +116,7 @@ public class ObjectClassInfoHelper {
 
     /**
      * Get a read only set of attributes should return by default.
-     * <p/>
+     * <p>
      * If the {@link OperationOptions#OP_ATTRIBUTES_TO_GET} attribute value is null this is the default always.
      *
      * @return set of attribute names to get for the object.

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/OperationType.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/commons/OperationType.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -28,9 +29,7 @@ import org.identityconnectors.framework.api.operations.*;
 
 /**
  * <p>Java class for OperationType.
- * <p/>
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p/>
  * <pre>
  * &lt;simpleType name="OperationType">
  *   &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderService.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2024 3A Systems LLC.
+ * Portions Copyrighted 2024-2026 3A Systems LLC.
  */
 package org.forgerock.openidm.provisioner.openicf.impl;
 
@@ -113,8 +113,6 @@ import org.slf4j.LoggerFactory;
  * The ConnectorInfoProviderService initiates the the embedded <a
  * href="http://openicf.forgerock.org">OpenICF</a> and makes it available as a
  * service.
- * <p/>
- *
  */
 @Component(
         name = ConnectorInfoProviderService.PID,

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2024 3A Systems LLC.
+ * Portions Copyrighted 2024-2026 3A Systems LLC.
  */
 package org.forgerock.openidm.provisioner.openicf.impl;
 
@@ -115,7 +115,6 @@ import static org.forgerock.json.resource.Responses.newActionResponse;
  * The OpenICFProvisionerService is the implementation of
  * {@link CollectionResourceProvider} interface with <a
  * href="http://openicf.forgerock.org">OpenICF</a>.
- * <p/>
  */
 @Component(
         name = OpenICFProvisionerService.PID,
@@ -565,7 +564,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
 
     /**
      * Gets the unique {@link org.forgerock.openidm.provisioner.SystemIdentifier} of this instance.
-     * <p/>
+     * <p>
      * The service which refers to this service instance can distinguish between multiple instances by this value.
      *
      * @return the system identifier
@@ -756,25 +755,25 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
     /**
      * This newBuilder and this method can not be scheduled. The call MUST go
      * through the {@code org.forgerock.openidm.provisioner}
-     * <p/>
+     * <p>
      * Invoked by the scheduler when the scheduler triggers.
-     * <p/>
+     * <p>
      * Synchronization object: {@code "connectorData" : "syncToken" :
      * "1305555929000", "nativeType" : "JAVA_TYPE_LONG" },
      * "synchronizationStatus" : { "errorStatus" : null, "lastKnownServer" :
      * "localServer", "lastModDate" : "2011-05-16T14:47:58.587Z", "lastModNum" :
      * 668, "lastPollDate" : "2011-05-16T14:47:52.875Z", "lastStartTime" :
      * "2011-05-16T14:29:07.863Z", "progressMessage" : "SUCCEEDED" } }}
-     * <p/>
+     * <p>
      * {@inheritDoc} Synchronize the changes from the end system for the given
      * {@code objectType}.
-     * <p/>
+     * <p>
      * OpenIDM takes active role in the synchronization process by asking the
      * end system to get all changed object. Not all systems are capable to
      * fulfill this kind of request but if the end system is capable then the
      * implementation sends each change to a new request on the router and when
      * it is finished, it returns a new <b>stage</b> object.
-     * <p/>
+     * <p>
      * The {@code previousStage} object is the previously returned value of this
      * method.
      *
@@ -792,8 +791,7 @@ public class OpenICFProvisionerService implements ProvisionerService, SingletonR
      *             connector.
      * @throws org.forgerock.json.JsonValueException
      *             if the {@code previousStage} is not Map.
-     * @see {@link ConnectorUtil#convertToSyncToken(org.forgerock.json.JsonValue)}
-     *      or any exception happed inside the connector.
+     * @see org.forgerock.openidm.provisioner.openicf.commons.ConnectorUtil#convertToSyncToken(org.forgerock.json.JsonValue)
      */
     public JsonValue liveSynchronize(final Context context, final String objectType, final JsonValue previousStage)
             throws ResourceException {

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OperationHelperImpl.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/impl/OperationHelperImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -139,7 +140,7 @@ public class OperationHelperImpl implements OperationHelper {
 
     /**
      * Generate the fully qualified id from unqualified object {@link org.identityconnectors.framework.common.objects.Uid}
-     * <p/>
+     * <p>
      * The result id will be system/{@code [endSystemName]}/{@code [objectType]}/{@code [escapedObjectId]}
      *
      * @param uid original un escaped unique identifier of the object

--- a/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/syncfailure/SyncHandlerException.java
+++ b/openidm-provisioner-openicf/src/main/java/org/forgerock/openidm/provisioner/openicf/syncfailure/SyncHandlerException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 ForgeRock, AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms of the Common Development and
  * Distribution License (the License). You may not use this file except in compliance with the
@@ -21,16 +22,11 @@ package org.forgerock.openidm.provisioner.openicf.syncfailure;
  */
 public class SyncHandlerException extends RuntimeException {
     static final long serialVersionUID = 1L;
-    /**
-     * {@inheritDoc}
-     */
+
     public SyncHandlerException(String message) {
         super(message);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public SyncHandlerException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/Id.java
+++ b/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/Id.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -40,12 +41,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Id is a util class to work with the {@code id} property in the
- * {@link org.forgerock.json.resource.JsonResource} interface.
- * <p/>
+ * {@code org.forgerock.json.resource.JsonResource} interface.
+ * <p>
  * A valid ID MAY start with {@code system} and followed by the name of the end
  * system, type of the object. The third token may be the local identifier of
  * the object instance.
- * <p/>
+ * <p>
  * Valid identifiers: {@code
  * system/LDAP/account
  * LDAP/account

--- a/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/ProvisionerService.java
+++ b/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/ProvisionerService.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -42,7 +43,7 @@ public interface ProvisionerService {
 
     /**
      * Gets the unique {@link SystemIdentifier} of this instance.
-     * <p/>
+     * <p>
      * The service which refers to this service instance can distinguish between multiple instances by this value.
      *
      * @return the provisioner's system identifier
@@ -51,7 +52,7 @@ public interface ProvisionerService {
 
     /**
      * Gets a brief stats report about the current status of this service instance.
-     * </p/>
+     * <p>
      * TODO Provide a sample object
      *
      * @param context the request's Context in case the status report operation needs to perform a router request
@@ -68,15 +69,15 @@ public interface ProvisionerService {
 
     /**
      * Synchronise the changes from the end system for the given {@code objectType}.
-     * <p/>
+     * <p>
      * OpenIDM takes active role in the synchronisation process by asking the end system to get all changed object.
      * Not all systems are capable to fulfill this kind of request but if the end system is capable then the
      * implementation sends each change to a new request on the router and when it is finished, it returns
      * a new <b>stage</b> object.
-     * <p/>
+     * <p>
      * The {@code previousStage} object is the previously returned value of this method.
      * Unhandled exception will result not to update the stage object in repository.
-     * <p/>
+     * <p>
      * All exceptions must be handled to save the the new stage object.
      *
      * @param context the request context associated with the invocation

--- a/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/SimpleSystemIdentifier.java
+++ b/openidm-provisioner/src/main/java/org/forgerock/openidm/provisioner/SimpleSystemIdentifier.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -33,7 +34,7 @@ import org.forgerock.json.JsonValueException;
 /**
  * SimpleSystemIdentifier class helps to match the id against the name of the
  * system configuration.
- * <p/>
+ * <p>
  * Matching id pattern: system/{@code name}/*
  *
  */

--- a/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/JobWrapper.java
+++ b/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/JobWrapper.java
@@ -2,6 +2,7 @@
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 *
 * Copyright 2012-2015 ForgeRock AS. All Rights Reserved
+* Portions Copyrighted 2026 3A Systems, LLC.
 *
 * The contents of this file are subject to the terms
 * of the Common Development and Distribution License
@@ -119,7 +120,6 @@ public class JobWrapper {
     /**
      * Sets the JobWrapper in the "paused" state.
      * 
-     * @return the paused JobWrapper
      */
     public void pause() {
         setPaused(true);
@@ -128,7 +128,6 @@ public class JobWrapper {
     /**
      * Resumes the JobWrapper from the paused state
      * 
-     * @return the resumed JobWrapper
      */
     public void resume() {
         setPaused(false);

--- a/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/RepoJobStoreUtils.java
+++ b/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/RepoJobStoreUtils.java
@@ -2,6 +2,7 @@
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 *
 * Copyright (c) 2012 ForgeRock AS. All Rights Reserved
+* Portions Copyrighted 2026 3A Systems, LLC.
 *
 * The contents of this file are subject to the terms
 * of the Common Development and Distribution License
@@ -41,7 +42,6 @@ public class RepoJobStoreUtils {
      * 
      * @param object the object to serialize.
      * @return a string representation of the serialized object.
-     * @throws Exception
      */
     public static String serialize(Serializable object) throws JobPersistenceException {
         try {
@@ -63,7 +63,6 @@ public class RepoJobStoreUtils {
      * 
      * @param str the representation of the serialized object
      * @return the deserialized object
-     * @throws Exception
      */
     public static Object deserialize(String str) throws JobPersistenceException {
         try {

--- a/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/package-info.java
+++ b/openidm-quartz-fragment/src/main/java/org/forgerock/openidm/quartz/impl/package-info.java
@@ -2,6 +2,7 @@
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 *
 * Copyright (c) 2012 ForgeRock AS. All Rights Reserved
+* Portions Copyrighted 2026 3A Systems, LLC.
 *
 * The contents of this file are subject to the terms
 * of the Common Development and Distribution License
@@ -24,7 +25,7 @@
 */
 
 /**
- * <h1>Package org.forgerock.openidm.scheduler</h1>
+ * <h2>Package org.forgerock.openidm.scheduler</h2>
  * 
  * This package contains a custom JobStore implementation that 
  * uses the OpenIDM Repository Service for persistence, a custom 

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DB2SQLExceptionHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DB2SQLExceptionHandler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -32,9 +33,6 @@ import java.sql.SQLException;
  */
 public class DB2SQLExceptionHandler extends DefaultSQLExceptionHandler {
 
-    /**
-     * @InheritDoc
-     */
     @Override
     public boolean isRetryable(SQLException ex, Connection connection) {
         // Re-tryable DB2 error codes

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DB2TableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DB2TableHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.repo.jdbc.impl;
 
@@ -78,9 +79,6 @@ public class DB2TableHandler extends GenericTableHandler {
     }
 
     // blatantly copied from OracleTableHandler...
-    /**
-     * @inheritDoc
-     */
     @Override
     public String renderQueryFilter(QueryFilter<JsonPointer> filter, Map<String, Object> replacementTokens, Map<String, Object> params) {
         final int offsetParam = Integer.parseInt((String)params.get(PAGED_RESULTS_OFFSET));

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DefaultSQLExceptionHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/DefaultSQLExceptionHandler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -38,16 +39,10 @@ import org.forgerock.openidm.repo.jdbc.SQLExceptionHandler;
  */
 public class DefaultSQLExceptionHandler implements SQLExceptionHandler {
 
-    /**
-     * @InheritDoc
-     */
     public boolean isErrorType(SQLException ex, ErrorType errorType) {
         return XOpenErrorMapping.isErrorType(ex, errorType);
     }
 
-    /**
-     * @InheritDoc
-     */
     public boolean isRetryable(SQLException ex, Connection connection) {
         // These are known re-tryable for MySQL. Other DBs may need specific sql exception handler defnitions.
         if (isErrorType(ex, ErrorType.CONNECTION_FAILURE) || isErrorType(ex, ErrorType.DEADLOCK_OR_TIMEOUT)

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/GenericTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/GenericTableHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.repo.jdbc.impl;
 
@@ -372,17 +373,11 @@ public class GenericTableHandler implements TableHandler {
         return batchingCount;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public boolean isErrorType(SQLException ex, ErrorType errorType) {
         return sqlExceptionHandler.isErrorType(ex, errorType);
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public boolean isRetryable(SQLException ex, Connection connection) {
         return sqlExceptionHandler.isRetryable(ex, connection);

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MSSQLExceptionHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MSSQLExceptionHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.repo.jdbc.impl;
 
@@ -42,9 +43,6 @@ public class MSSQLExceptionHandler extends DefaultSQLExceptionHandler {
     );
 
     
-    /**
-     * @inheritDoc
-     */
     @Override
     public boolean isRetryable(SQLException ex, Connection connection) {
         return super.isRetryable(ex, connection) || retryableErrors.contains(ex.getErrorCode());

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MSSQLTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MSSQLTableHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.repo.jdbc.impl;
@@ -152,9 +153,6 @@ public class MSSQLTableHandler extends GenericTableHandler {
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public String renderQueryFilter(QueryFilter<JsonPointer> filter, Map<String, Object> replacementTokens, Map<String, Object> params) {
         final int offsetParam = Integer.parseInt((String) params.get(PAGED_RESULTS_OFFSET));

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MappedTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MappedTableHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.repo.jdbc.impl;
@@ -485,9 +486,6 @@ public class MappedTableHandler implements TableHandler {
     }
 
     // TODO: make common to generic and explicit handlers
-    /**
-     * @inheritDoc
-     */
     public boolean isErrorType(SQLException ex, ErrorType errorType) {
         return sqlExceptionHandler.isErrorType(ex, errorType);
     }

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MySQLExceptionHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/MySQLExceptionHandler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -33,9 +34,6 @@ import org.forgerock.openidm.repo.jdbc.ErrorType;
  */
 public class MySQLExceptionHandler extends DefaultSQLExceptionHandler {
 
-    /**
-     * @InheritDoc
-     */
     public boolean isErrorType(SQLException ex, ErrorType errorType) {
         boolean result = XOpenErrorMapping.isErrorType(ex, errorType);
 

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/OracleTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/OracleTableHandler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2012-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -121,9 +122,6 @@ public class OracleTableHandler extends GenericTableHandler {
         return result;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public String renderQueryFilter(QueryFilter<JsonPointer> filter, Map<String, Object> replacementTokens, Map<String, Object> params) {
         final int offsetParam = Integer.parseInt((String)params.get(PAGED_RESULTS_OFFSET));

--- a/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/PostgreSQLTableHandler.java
+++ b/openidm-repo-jdbc/src/main/java/org/forgerock/openidm/repo/jdbc/impl/PostgreSQLTableHandler.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2012-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -120,8 +121,6 @@ public class PostgreSQLTableHandler extends GenericTableHandler {
 
     /**
      * Construct a table handler for Postgres using Postgres-specific json-handling
-     *
-     * {@inheritDoc}
      */
     public PostgreSQLTableHandler(JsonValue tableConfig, String dbSchemaName, JsonValue queriesConfig, JsonValue commandsConfig,
             int maxBatchSize, SQLExceptionHandler sqlExceptionHandler) {

--- a/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/OrientDBRepoService.java
+++ b/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/impl/OrientDBRepoService.java
@@ -517,14 +517,6 @@ public class OrientDBRepoService implements RequestHandler, RepositoryService, R
      *            the parameters of the query to perform.
      * @return the query results, which includes meta-data and the result
      *         records in JSON object structure format.
-     * @throws NotFoundException
-     *             if the specified object could not be found.
-     * @throws BadRequestException
-     *             if the specified params contain invalid arguments, e.g. a
-     *             query id that is not configured, a query expression that is
-     *             invalid, or missing query substitution tokens.
-     * @throws ForbiddenException
-     *             if access to the object or specified query is forbidden.
      */
     @Override
     public Promise<QueryResponse, ResourceException> handleQuery(final Context context, final QueryRequest request,

--- a/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/metadata/ConfigMeta.java
+++ b/openidm-repo-orientdb/src/main/java/org/forgerock/openidm/repo/orientdb/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -49,9 +50,6 @@ public class ConfigMeta implements MetaDataProvider {
         propertiesToEncrypt = Collections.unmodifiableList(props);
     }
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) {
         if (OrientDBRepoService.PID.equals(pidOrFactory)) {
@@ -60,9 +58,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
     }

--- a/openidm-repo/src/main/java/org/forgerock/openidm/repo/QueryConstants.java
+++ b/openidm-repo/src/main/java/org/forgerock/openidm/repo/QueryConstants.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -41,7 +42,7 @@ public final class QueryConstants {
      *
      * The alternative is to specify a query identifier for a pre-configured query. 
      * 
-     * The query can contain tokens in the form of ${<param-map-key>} which will 
+     * The query can contain tokens in the form of {@code ${<param-map-key>}} which will
      * get substituted from the param map passed to the query.
      * 
      * When both an expression and ID are present, the query expression takes precedent
@@ -56,7 +57,7 @@ public final class QueryConstants {
      * 
      * The alternative is to specify a query expression for an in-line query.
      *
-     * The configured query can contain tokens in the form of ${<param-map-key>}
+     * The configured query can contain tokens in the form of {@code ${<param-map-key>}}
      * which will get substituted from the param map passed to the query.
      * 
      * When both an expression and ID are present, the query expression takes precedent
@@ -82,7 +83,7 @@ public final class QueryConstants {
     /**
      * Query output key.
      * 
-     * Key for record results in JSON object model format, value format List<Map<String, Object>>
+     * Key for record results in JSON object model format, value format {@code List<Map<String, Object>>}
      */
     public final static String QUERY_RESULT = "result";    
     

--- a/openidm-repo/src/main/java/org/forgerock/openidm/repo/RepoBootService.java
+++ b/openidm-repo/src/main/java/org/forgerock/openidm/repo/RepoBootService.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011-2013 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -69,10 +70,10 @@ public interface RepoBootService {
 
     /**
      * Updates a resource in the repository
-     * <p/>
+     * <p>
      * This implementation requires MVCC and hence enforces that clients state
      * what revision they expect to be updating
-     * <p/>
+     * <p>
      * If successful, this method updates metadata properties within the passed
      * object, including: a new {@code _rev} value for the revised object's
      * version

--- a/openidm-repo/src/main/java/org/forgerock/openidm/repo/RepositoryService.java
+++ b/openidm-repo/src/main/java/org/forgerock/openidm/repo/RepositoryService.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -68,10 +69,10 @@ public interface RepositoryService {
     
     /**
      * Updates a resource in the repository
-     * <p/>
+     * <p>
      * This implementation requires MVCC and hence enforces that clients state
      * what revision they expect to be updating
-     * <p/>
+     * <p>
      * If successful, this method updates metadata properties within the passed
      * object, including: a new {@code _rev} value for the revised object's
      * version

--- a/openidm-repo/src/main/java/org/forgerock/openidm/repo/util/AbstractSQLQueryFilterVisitor.java
+++ b/openidm-repo/src/main/java/org/forgerock/openidm/repo/util/AbstractSQLQueryFilterVisitor.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -61,6 +62,7 @@ import org.forgerock.util.query.QueryFilterVisitor;
  *     function AND behaves</li>
  *     <li>@{link #visitOrFilter(Object, List&lt;QueryFilter&gt;, Object)} to dictate how the composite
  *     function OR behaves</li>
+ * </ul>
  *
  * @param <R> the subclass of SQLRenderer the visitor returns
  * @param <P> the parameter type passed in the visit methods
@@ -71,18 +73,18 @@ public abstract class AbstractSQLQueryFilterVisitor<R extends SQLRenderer<?>, P>
      * A templating method that will generate the actual value assertion.
      * <p>
      * Example:
-     * <pre><blockquote>
+     * <pre>
      *     ?_queryFilter=email+eq+"someone@example.com"
-     * </blockquote></pre>
+     * </pre>
      * is an QueryFilter stating the value assertion "email" equals "someone@example.com".  The correct SQL for that
      * may vary depending on database variant and schema definition.  This method will be invoked as
-     * <pre><blockquote>
+     * <pre>
      *     return visitValueAssertion(parameters, "=", JsonPointer(/email), "someone@example.com");
-     * </blockquote></pre>
+     * </pre>
      * A possible implementation for the above example may be
-     * <pre><blockquote>
+     * <pre>
      *     return getDatabaseColumnFor("email") + "=" + ":email";
-     * </blockquote></pre>
+     * </pre>
      * The parameters argument is implementation-dependent as a way to store placeholder mapping throughout the query-filter visiting.
      *
      * @param parameters storage of parameter-substitutions for the value of the assertion

--- a/openidm-repo/src/main/java/org/forgerock/openidm/repo/util/StringSQLQueryFilterVisitor.java
+++ b/openidm-repo/src/main/java/org/forgerock/openidm/repo/util/StringSQLQueryFilterVisitor.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2014-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -70,18 +71,18 @@ public abstract class StringSQLQueryFilterVisitor<P> extends AbstractSQLQueryFil
      * A templating method that will generate the actual value assertion.
      * <p>
      * Example:
-     * <pre><blockquote>
+     * <pre>
      *     ?_queryFilter=email+eq+"someone@example.com"
-     * </blockquote></pre>
+     * </pre>
      * is an QueryFilter stating the value assertion "email" equals "someone@example.com".  The correct SQL for that
      * may vary depending on database variant and schema definition.  This method will be invoked as
-     * <pre><blockquote>
+     * <pre>
      *     return visitValueAssertion(parameters, "=", JsonPointer(/email), "someone@example.com");
-     * </blockquote></pre>
+     * </pre>
      * A possible implementation for the above example may be
-     * <pre><blockquote>
+     * <pre>
      *     return getDatabaseColumnFor("email") + "=" + ":email";
-     * </blockquote></pre>
+     * </pre>
      * The parameters argument is implementation-dependent as a way to store placeholder mapping throughout the query-filter visiting.
      *
      * @param parameters storage of parameter-substitutions for the value of the assertion

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/IDMConnectionFactory.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/IDMConnectionFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.router;
@@ -27,7 +28,7 @@ import org.forgerock.util.promise.Promise;
  */
 public interface IDMConnectionFactory extends ConnectionFactory {
     /**
-     * Returns a <em><external</em> connection to the JSON resource provider associated
+     * Returns a <em>external</em> connection to the JSON resource provider associated
      * with this connection factory. The connection returned by this method
      * can be used immediately.
      *

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/RouteEvent.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/RouteEvent.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -97,7 +98,6 @@ public class RouteEvent extends EventObject {
 
     /**
      * Returns a {@code Router} where a change had occurred in.
-     * <p>
      *
      * @return {@code Router} that had the change.
      */

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/RouteListener.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/RouteListener.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -29,11 +30,11 @@ import org.osgi.framework.ServiceEvent;
 import java.util.EventListener;
 
 /**
- * @ThreadSafe
+ * This interface is thread-safe.
  */
 public interface RouteListener extends EventListener {
     /**
-     * Receives notification that a {@link org.forgerock.http.routing.RouteMatcher} has had a lifecycle change.
+     * Receives notification that a {@code org.forgerock.http.routing.RouteMatcher} has had a lifecycle change.
      *
      * @param event The {@code ServiceEvent} object.
      */

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/metadata/ConfigMeta.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/metadata/ConfigMeta.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2014-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -46,9 +47,6 @@ public class ConfigMeta implements MetaDataProvider {
      */
     final static Logger logger = LoggerFactory.getLogger(ConfigMeta.class);
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias, JsonValue config)
             throws WaitForMetaData, NotConfiguration {
         if (JsonResourceRouterService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -58,9 +56,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This instance won't be updated

--- a/openidm-router/src/main/java/org/forgerock/openidm/router/package-info.java
+++ b/openidm-router/src/main/java/org/forgerock/openidm/router/package-info.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -24,7 +25,7 @@
 
 /**
  * OpenIDM router classes
- * <p/>
+ * <p>
  * This package contains the core routing implementation of OpenIDM.
  */
 package org.forgerock.openidm.router;

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedRequestHandler.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/ScriptedRequestHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.script;
@@ -98,8 +99,7 @@ public class ScriptedRequestHandler implements Scope, RequestHandler {
 
     /**
      * Eventually set the script value.
-     * <p/>
-     * 
+     *
      * @param newScriptEntry
      * @throws NullPointerException
      *             when the {@code newScriptEntry} is null.

--- a/openidm-script/src/main/java/org/forgerock/openidm/script/impl/metadata/ConfigMeta.java
+++ b/openidm-script/src/main/java/org/forgerock/openidm/script/impl/metadata/ConfigMeta.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.script.impl.metadata;
@@ -48,9 +50,6 @@ public class ConfigMeta implements MetaDataProvider {
      */
     final static Logger logger = LoggerFactory.getLogger(ConfigMeta.class);
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias,
             JsonValue config) throws WaitForMetaData, NotConfiguration {
         if (ScriptRegistryService.PID.equalsIgnoreCase(pidOrFactory)) {
@@ -60,9 +59,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         // This newBuilder won't be updated

--- a/openidm-servlet-registrator/src/main/java/org/forgerock/openidm/servletregistration/ServletRegistration.java
+++ b/openidm-servlet-registrator/src/main/java/org/forgerock/openidm/servletregistration/ServletRegistration.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 
 package org.forgerock.openidm.servletregistration;
@@ -83,7 +83,6 @@ public interface ServletRegistration {
      * @param initparams initialization arguments for the servlet or
      *        <code>null</code> if there are none. This argument is used by the
      *        servlet's <code>ServletConfig</code> object.
-     * @throws Exception if a problem occurs registering a servlet filter
      */
     @SuppressWarnings("rawtypes")
     void registerServlet(String alias, Servlet servlet, Dictionary initparams) throws ServletException, NamespaceException;

--- a/openidm-shell/src/main/java/org/forgerock/openidm/shell/CustomCommandScope.java
+++ b/openidm-shell/src/main/java/org/forgerock/openidm/shell/CustomCommandScope.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -48,7 +49,7 @@ public abstract class CustomCommandScope {
 
     /**
      * Get the {@link org.apache.felix.service.command.CommandProcessor#COMMAND_FUNCTION} value.
-     * <p/>
+     * <p>
      * TODO add description
      *
      * @return retrun a new map where the key is the command name and the value is the description.
@@ -57,7 +58,7 @@ public abstract class CustomCommandScope {
 
     /**
      * Get the {@link org.apache.felix.service.command.CommandProcessor#COMMAND_SCOPE} value.
-     * <p/>
+     * <p>
      * TODO add description
      *
      * @return the scope value

--- a/openidm-shell/src/main/java/org/forgerock/openidm/shell/felixgogo/MetaVar.java
+++ b/openidm-shell/src/main/java/org/forgerock/openidm/shell/felixgogo/MetaVar.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.shell.felixgogo;
 
@@ -27,8 +28,8 @@ import java.lang.annotation.Target;
  * Example:
  *
  * <pre>
- *     @Parameter(names = {"--user"})
- *     @MetaVar("USERNAME")
+ *     {@literal @}Parameter(names = {"--user"})
+ *     {@literal @}MetaVar("USERNAME")
  *     final String username
  * </pre>
  *

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/BlockingPublisher.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/BlockingPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012-2014 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -74,9 +75,6 @@ public class BlockingPublisher implements PluggablePublisher {
         return INSTANCE;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final EventEntry start(Name eventName, Object payload, Object context) {
         EventEntryImpl eventEntry = new EventEntryImpl();
         eventEntry.eventName = eventName;
@@ -88,15 +86,9 @@ public class BlockingPublisher implements PluggablePublisher {
         return eventEntry;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result, EventEntry entry) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end(Name eventName, EventEntry entry) {
         try {
             queue.put(entry);

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisabledEventEntry.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisabledEventEntry.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -29,21 +30,12 @@ public class DisabledEventEntry implements EventEntry {
 
     Name eventName;
 
-    /**
-     * @inheritDoc
-     */
     public final void start() {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end() {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result) {
     }
 

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisabledPublisher.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisabledPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -33,22 +34,13 @@ public class DisabledPublisher implements PluggablePublisher {
         return INSTANCE;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final EventEntry start(Name eventName, Object payload, Object context) {
         return ENTRY;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result, EventEntry delegate) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end(Name eventName, EventEntry callingEntry) {
     }
 }

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorReferringEventEntry.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorReferringEventEntry.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -46,9 +47,6 @@ public class DisruptorReferringEventEntry {
                 }
             };
 
-    /**
-     * @inheritDoc
-     */
     public final void end() {
         // Disabled when using batched end time
         // The low latency batching framework will assign the time

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorReferringPublisher.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorReferringPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -77,9 +78,6 @@ public class DisruptorReferringPublisher implements PluggablePublisher {
         return INSTANCE;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final EventEntry start(Name eventName, Object payload, Object context) {
         // For start event, do not hold a place in the ringbuffer (yet)
         // to avoid limiting long running measurements
@@ -95,15 +93,9 @@ public class DisruptorReferringPublisher implements PluggablePublisher {
         return eventEntry;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result, EventEntry delegate) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end(Name eventName, EventEntry delegate) {
         sequence = ringBuffer.next();
         final DisruptorReferringEventEntry eventEntry = ringBuffer.claimAndGetPreallocated(sequence);

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorShortEventEntry.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorShortEventEntry.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -54,25 +55,16 @@ public class DisruptorShortEventEntry implements EventEntry {
                 }
             };
 
-    /**
-     * @inheritDoc
-     */
     final void start() {
         startTime = System.nanoTime();
         endTime = 0;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end() {
         // User called this end() method directly, delegate the event publishing
         publisher.end(eventName, this);
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result) {
         this.result = result;
     }

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorShortPublisher.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/DisruptorShortPublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -70,9 +71,6 @@ public class DisruptorShortPublisher implements PluggablePublisher {
         return INSTANCE;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final EventEntry start(Name eventName, Object payload, Object context) {
         sequence = ringBuffer.next();
         final DisruptorShortEventEntry eventEntry = ringBuffer.claimAndGetPreallocated(sequence);
@@ -87,15 +85,9 @@ public class DisruptorShortPublisher implements PluggablePublisher {
         return eventEntry;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result, EventEntry delegate) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end(Name eventName, EventEntry callingEntry) {
         // This end() gets called indirectly after the EventEntry end() gets
         // invoked by the user

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/EventEntryImpl.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/EventEntryImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -39,9 +40,6 @@ public class EventEntryImpl implements EventEntry {
 
     PluggablePublisher publisher;
 
-    /**
-     * @inheritDoc
-     */
     final void start() {
         // TODO: provide option for millis
         // startTime = System.currentTimeMillis();
@@ -49,18 +47,12 @@ public class EventEntryImpl implements EventEntry {
         endTime = 0;
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void end() {
         // User called this end() method directly, delegate the event publishing
         endTime = System.nanoTime();
         publisher.end(eventName, this);
     }
 
-    /**
-     * @inheritDoc
-     */
     public final void setResult(Object result) {
         this.publisherResultSet = true;
         if (eventName.getResultHistoryEnabled()) {

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/PluggablePublisher.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/PluggablePublisher.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -28,7 +29,7 @@ public interface PluggablePublisher {
     /**
      * Pluggable implementation of the start event handling, used internally
      * 
-     * @see org.forgerock.smartevent.Publisher
+     * @see org.forgerock.openidm.smartevent.Publisher
      */
     EventEntry start(Name eventName, Object payload, Object context);
 
@@ -37,7 +38,7 @@ public interface PluggablePublisher {
      * Invoked indirectly as part of the
      * <code>org.forgerock.smartevent.EventEntry.setResult()</code> processing
      * 
-     * @see org.forgerock.smartevent.Publisher
+     * @see org.forgerock.openidm.smartevent.Publisher
      */
     void setResult(Object result, EventEntry callingEntry);
 
@@ -46,7 +47,7 @@ public interface PluggablePublisher {
      * Invoked indirectly as part of the
      * <code>org.forgerock.smartevent.EventEntry.end()</code> processing
      * 
-     * @see org.forgerock.smartevent.Publisher
+     * @see org.forgerock.openidm.smartevent.Publisher
      */
     void end(Name eventName, EventEntry callingEntry);
 }

--- a/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/StatisticsHandler.java
+++ b/openidm-smartevent/src/main/java/org/forgerock/openidm/smartevent/core/StatisticsHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2012 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.smartevent.core;
@@ -126,9 +127,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     public Map<String, String> getTotals() {
         Map<String, String> stats = new TreeMap<>();
         for (Map.Entry<String, MonitoringInfo> entry : map.entrySet()) {
@@ -137,9 +135,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
         return stats;
     }
 
-    /**
-     * @inheritDoc
-     */
     public Map<Long, String> getRecent() {
         // TODO: consider adding history for not yet end()-ed events
         // Present history ordered by start time, with latest start time first
@@ -163,18 +158,12 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
         return recent;
     }
 
-    /**
-     * @inheritDoc
-     */
     public void resetAllStatistics() {
         for (MonitoringInfo entry : map.values()) {
             entry.reset();
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     public void resetStatistics(String eventName) {
         MonitoringInfo entry = map.get(eventName);
         if (entry != null) {
@@ -186,9 +175,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
     }
 
     // TODO: move out of statistics
-    /**
-     * @inheritDoc
-     */
     public void setEventsEnabled(String eventName, boolean enabled) {
         Name entry = Name.get(eventName);
         if (entry != null) {
@@ -200,9 +186,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
     }
 
     // TODO: move out of statistics
-    /**
-     * @inheritDoc
-     */
     public Map<String, Boolean> getEventsEnabledMap() {
         Map<String, Boolean> enabledMap = new TreeMap<String, Boolean>();
         for (Map.Entry<String, Name> entry : Name.getAllNames().entrySet()) {
@@ -212,9 +195,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
     }
 
     // TODO: move out of statistics
-    /**
-     * @inheritDoc
-     */
     public void setResultHistoryEnabled(String eventName, boolean enabled) {
         Name entry = Name.get(eventName);
         if (entry != null) {
@@ -226,9 +206,6 @@ public class StatisticsHandler implements EventHandler<DisruptorReferringEventEn
     }
 
     // TODO: move out of statistics
-    /**
-     * @inheritDoc
-     */
     public Map<String, Boolean> getResultHistoryEnabledMap() {
         Map<String, Boolean> enabledMap = new TreeMap<String, Boolean>();
         for (Map.Entry<String, Name> entry : Name.getAllNames().entrySet()) {

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/IdentityServer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.core;
@@ -108,7 +109,7 @@ public final class IdentityServer implements PropertyAccessor {
     /**
      * Initialise the singleton {@link IdentityServer} instance with the
      * provided {@link PropertyAccessor} instance.
-     * <p/>
+     * <p>
      * This or the {@link #initInstance(IdentityServer)} method can be called
      * only once and then it throws {@link IllegalStateException} if it's called
      * more then once.
@@ -132,7 +133,7 @@ public final class IdentityServer implements PropertyAccessor {
     /**
      * Initialise the singleton {@link IdentityServer} instance with the
      * provided {@link IdentityServer} instance.
-     * <p/>
+     * <p>
      * This or the {@link #initInstance(PropertyAccessor)} method can be called
      * only once and then it throws {@link IllegalStateException} if it's called
      * more then once.

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/PropertyUtil.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/PropertyUtil.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.core;
@@ -95,7 +96,7 @@ public class PropertyUtil {
                     });
 
     /**
-     * Tests if the passed in value contains the delimited property, ie &{property} or ${property}
+     * Tests if the passed in value contains the delimited property, ie &amp;{property} or ${property}
      * @param value the value to test
      * @param property the property to look for in the passed value.
      * @return true if the passed value contains the delimited property.
@@ -119,7 +120,7 @@ public class PropertyUtil {
      * <p>
      * This method performs property variable substitution on the specified
      * value. If the specified value contains the syntax
-     * <tt>&{&lt;prop-name&gt;}</tt>, where <tt>&lt;prop-name&gt;</tt> refers to
+     * <code>&amp;{&lt;prop-name&gt;}</code>, where <code>&lt;prop-name&gt;</code> refers to
      * either a configuration property or a system property, then the
      * corresponding property value is substituted for the variable placeholder.
      * Multiple variable placeholders may exist in the specified value as well

--- a/openidm-system/src/main/java/org/forgerock/openidm/core/ServerConstants.java
+++ b/openidm-system/src/main/java/org/forgerock/openidm/core/ServerConstants.java
@@ -31,7 +31,7 @@ package org.forgerock.openidm.core;
 /**
  * This class defines a set of constants that may be referenced throughout the
  * Identity Server source.
- * <p/>
+ * <p>
  * Based on OpenDJ ServerConstants
  */
 public final class ServerConstants {

--- a/openidm-util/src/main/java/org/forgerock/openidm/osgi/OsgiName.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/osgi/OsgiName.java
@@ -15,6 +15,8 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.osgi;
 
@@ -34,7 +36,7 @@ import javax.naming.NamingException;
  * Based on apache aries org/apache/aries/jndi/url/OsgiName.java apache aries
  * org/apache/aries/jndi/url/OsgiNameParser.java
  *
- * <p/>
+ * <p>
  * component 0: osgi:framework, osgi:service, openidm:services, osgi:servicelist
  * component 1: interface component 2: filter
  *
@@ -154,7 +156,7 @@ public class OsgiName extends CompositeName {
 
     /**
      * Parse the String representation of a OSGi Object name.
-     * <p/>
+     * <p>
      * Example:
      * {@code osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/openidm)}
      *

--- a/openidm-util/src/main/java/org/forgerock/openidm/patch/PatchValueTransformer.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/patch/PatchValueTransformer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.patch;
@@ -33,7 +34,6 @@ public interface PatchValueTransformer {
      * @param subject The patch subject document.  Subject is unused by default, made available
      *               for use by custom transforms.
      * @return JsonValue to be used for a given patch operation
-     * @return subject on patch null or empty
      * @throws BadRequestException on null subject, null scriptConfig
      * @throws ResourceException on script execution error
      */

--- a/openidm-util/src/main/java/org/forgerock/openidm/util/FileUtil.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/util/FileUtil.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.util;
@@ -33,7 +34,7 @@ public final class FileUtil {
     }
 
     /**
-     * Read small < 5Mb text files to String.
+     * Read small &lt; 5Mb text files to String.
      *
      * @param file
      *            source file

--- a/openidm-util/src/main/java/org/forgerock/openidm/util/ResourceUtil.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/util/ResourceUtil.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.util;
@@ -63,7 +65,6 @@ public class ResourceUtil {
 
     /**
      * Retrieve the {@code UriTemplateVariables} from the context.
-     * <p/>
      *
      * @param context
      *

--- a/openidm-util/src/main/java/org/forgerock/openidm/util/Script.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/util/Script.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.util;
@@ -25,7 +26,7 @@ import org.forgerock.script.ScriptEntry;
 import org.forgerock.services.context.Context;
 
 /**
- * This class wraps a {@link ScriptEntry} object representing a script stored in the {@link ScriptRegistry} and 
+ * This class wraps a {@link ScriptEntry} object representing a script stored in the {@link org.forgerock.script.ScriptRegistry} and
  * provides a method for executing the script with a given {@link Context} and scope variables. 
  */
 public class Script {

--- a/openidm-util/src/main/java/org/forgerock/openidm/util/Scripts.java
+++ b/openidm-util/src/main/java/org/forgerock/openidm/util/Scripts.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.util;
 
@@ -44,11 +45,11 @@ public class Scripts {
     }
 
     /**
-     * Returns a new {@link Script} object representing a {@link ScriptEntry} from the {@link ScriptRegistry} service 
+     * Returns a new {@link Script} object representing a {@link org.forgerock.script.ScriptEntry} from the {@link ScriptRegistry} service
      * based on the passed in script configuration.  Returns null if the passed is script configuration is null.
      * 
      * @param config a script configuration.
-     * @return a {@link Script} object representing a {@link ScriptEntry} from the {@link ScriptRegistry} service.
+     * @return a {@link Script} object representing a {@link org.forgerock.script.ScriptEntry} from the {@link ScriptRegistry} service.
      * @throws JsonValueException
      */
     public static Script newScript(JsonValue config) throws JsonValueException {

--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/SharedIdentityService.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/impl/SharedIdentityService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.workflow.activiti.impl;
 
@@ -282,7 +283,7 @@ public class SharedIdentityService implements IdentityService {
      * Retrieves the picture for a given user.
      *
      * @throws org.activiti.engine.ActivitiException if the user doesn't exist.
-     * @returns null if the user doesn't have a picture.
+     * @return null if the user doesn't have a picture.
      */
     public Picture getUserPicture(String userId) {
         return null;

--- a/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/metadata/ConfigMeta.java
+++ b/openidm-workflow-activiti/src/main/java/org/forgerock/openidm/workflow/activiti/metadata/ConfigMeta.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.workflow.activiti.metadata;
 
@@ -47,9 +48,6 @@ public class ConfigMeta implements MetaDataProvider {
         propertiesToEncrypt.put(ActivitiServiceImpl.PID, props);
     }
 
-    /**
-     * @inheritDoc
-     */
     public List<JsonPointer> getPropertiesToEncrypt(String pidOrFactory, String instanceAlias, JsonValue config) {
         if (propertiesToEncrypt.containsKey(pidOrFactory)) {
             return propertiesToEncrypt.get(pidOrFactory);
@@ -57,9 +55,6 @@ public class ConfigMeta implements MetaDataProvider {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public void setCallback(MetaDataProviderCallback callback) {
         this.callback = callback;

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
 
+        <!-- Javadoc doclint level, inherited by every module. -->
+        <doclint>all,-missing</doclint>
+
 
         <!-- Third party dependency versions -->
         <mybatis.version>3.5.16</mybatis.version>
@@ -750,9 +753,24 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
                 <configuration>
-                    <doclint>none</doclint>
+                    <doclint>${doclint}</doclint>
                     <notimestamp>true</notimestamp>
+                    <failOnWarnings>true</failOnWarnings>
+                    <!--
+                        Guava classes referenced from public API (e.g. AtomicDouble) are annotated with
+                        com.google.j2objc.annotations.ReflectionSupport, which Guava declares optional. Put it
+                        on the Javadoc classpath so the annotation's enum resolves instead of emitting
+                        "unknown enum constant Level.FULL" warnings (which would fail failOnWarnings).
+                    -->
+                    <additionalDependencies>
+                        <additionalDependency>
+                            <groupId>com.google.j2objc</groupId>
+                            <artifactId>j2objc-annotations</artifactId>
+                            <version>3.0.0</version>
+                        </additionalDependency>
+                    </additionalDependencies>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary

Make the Javadoc build strict (`failOnWarnings=true`) and fix every existing doclint error/warning so it stays green across the CI JDK matrix (17–26).

### `pom.xml`
- Add an inherited `doclint` property (`all,-missing`) and reference it from `maven-javadoc-plugin` via `${doclint}` (was `doclint=none`).
- Bump `maven-javadoc-plugin` 3.11.2 → **3.12.0** and enable `<failOnWarnings>true</failOnWarnings>`.
- Add `j2objc-annotations:3.0.0` to the Javadoc classpath via `<additionalDependencies>` so Guava's `@ReflectionSupport(Level.FULL)` resolves instead of emitting a warning that would trip `failOnWarnings`.

There were no per-module doclint overrides to drop — only the root pom carried it.

### Doclint fixes
218 issues in 92 files across 26 modules — **Javadoc comments/headers only, no code changes**:
- block `@inheritDoc` on overrides → redundant comment removed
- self-closing `<p/>` / `</p/>`, empty `<p>`, `<tt>`→`<code>`, `<blockquote>`/`<pre>` nesting, `<caption>` for tables, bad `&{` entities
- broken/typo'd `{@link}` / `{@Link}` / `@see`, nested `{@link}`
- stale `@throws` / `@param` / `@return` (not thrown / wrong name / on void), duplicate `@return`

### Verification
Full-reactor `mvn javadoc:jar` builds clean with **0 doclint warnings** and produces all 40 module javadoc jars on both **JDK 17** and **JDK 26**. No Java module is skipped; only pom/JS aggregator modules without Java sources are inherently skipped by the plugin.
