### PR TITLE
Re-enable three previously disabled tests

### DIFF
--- a/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderServiceTest.java
+++ b/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/ConnectorInfoProviderServiceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openidm.provisioner.openicf.impl;
@@ -202,20 +203,22 @@ public class ConnectorInfoProviderServiceTest {
                 .isNotEmpty();
     }
 
-    @Test(enabled = false)
+    @Test
     public void testPropertiesToEncrypt() throws Exception {
+        // The original Solaris connector fixture was removed from the platform; exercise the same
+        // "confidential configuration property" detection path against the Groovy connector, whose
+        // schema marks customSensitiveConfiguration as a GuardedString.
         InputStream inputStream =
                 ConnectorInfoProviderServiceTest.class
-                        .getResourceAsStream("/config/org.forgerock.openidm.provisioner.openicf.impl.OpenICFProvisionerServiceSolarisConnectorTest.json");
+                        .getResourceAsStream("/config/provisioner.openicf-groovy.json");
         assertThat(inputStream).isNotNull();
 
         List<JsonPointer> result =
                 testableConnectorInfoProvider.getPropertiesToEncrypt(OpenICFProvisionerService.PID,
                         null, new JsonValue(mapper.readValue(inputStream, Map.class)));
         String[] expected =
-                new String[] { "/configurationProperties/password",
-                    "/configurationProperties/credentials", "/configurationProperties/privateKey",
-                    "/configurationProperties/passphrase" };
+                new String[] { "/configurationProperties/customSensitiveConfiguration" };
+        assertThat(result).isNotEmpty();
         for (JsonPointer pointer : result) {
             assertThat(expected).contains(pointer.toString());
         }

--- a/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerServiceTest.java
+++ b/openidm-provisioner-openicf/src/test/java/org/forgerock/openidm/provisioner/openicf/impl/OpenICFProvisionerServiceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.provisioner.openicf.impl;
 
@@ -852,7 +853,7 @@ public class OpenICFProvisionerServiceTest implements RouterRegistry, SyncFailur
     }
 
 
-    @Test(dataProvider = "groovy-only", enabled = false)
+    @Test(dataProvider = "groovy-only")
     public void testPagedSearch(String systemName) throws Exception {
 
         for (int i = 0; i < 100; i++) {

--- a/openidm-scheduler/src/test/java/org/forgerock/openidm/scheduler/ScheduleConfigServiceTest.java
+++ b/openidm-scheduler/src/test/java/org/forgerock/openidm/scheduler/ScheduleConfigServiceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.openidm.scheduler;
 
@@ -47,7 +48,7 @@ public class ScheduleConfigServiceTest {
         assertThat(scheduleConfig.getStartTime()).isNotNull();
     }
 
-    @Test(enabled = false, expectedExceptions = ResourceException.class)
+    @Test(expectedExceptions = ResourceException.class)
     public void invalidConfigParsingTest() throws ResourceException {
         // Check invalid configuration fails
         Map<String, Object> config = new HashMap<String, Object>();


### PR DESCRIPTION
## What

Three TestNG methods were annotated `enabled = false` and therefore never executed in the default `mvn test` build. This re-enables them.

| Test | Module | Result |
|---|---|---|
| `ScheduleConfigServiceTest.invalidConfigParsingTest` | openidm-scheduler | ✅ passes as-is |
| `OpenICFProvisionerServiceTest.testPagedSearch` (groovy, groovyremote) | openidm-provisioner-openicf | ✅ passes |
| `ConnectorInfoProviderServiceTest.testPropertiesToEncrypt` | openidm-provisioner-openicf | ✅ passes (retargeted) |

## Notes on `testPropertiesToEncrypt`

Its original classpath fixture `org.forgerock.openidm.provisioner.openicf.impl.OpenICFProvisionerServiceSolarisConnectorTest.json` had been deleted (commit ef25ec3a5, 2013) and the Solaris connector no longer exists in the OpenICF platform (available connectors: csvfile, databasetable, groovy, kerberos, ldap, ssh, xml). Restoring the fixture alone fails with `WaitForMetaData: ConnectorInfo is not available` because the connector bundle cannot be loaded.

The test's intent — verifying that `getPropertiesToEncrypt` returns the pointers to confidential/`GuardedString` configuration properties — is preserved by retargeting it to the Groovy connector (already copied into the test connectors directory), whose schema marks `customSensitiveConfiguration` as a `GuardedString`. An `assertThat(result).isNotEmpty()` guard was added so the assertion loop no longer passes vacuously on an empty result.

## Verification

- `mvn -pl openidm-scheduler test -Dtest=ScheduleConfigServiceTest` → 2/2 pass
- `mvn -pl openidm-provisioner-openicf test -Dtest=ConnectorInfoProviderServiceTest` → 4/4 pass
- `mvn -pl openidm-provisioner-openicf test -Dtest=OpenICFProvisionerServiceTest#testPagedSearch` → 2/2 pass
